### PR TITLE
fix(tui): standardize numeric formatting and add volume unit toggle

### DIFF
--- a/crates/cdcx-tui/src/app.rs
+++ b/crates/cdcx-tui/src/app.rs
@@ -253,6 +253,24 @@ impl App {
             return;
         }
 
+        // Volume unit toggle (v)
+        if key.code == KeyCode::Char('v') {
+            self.state.volume_unit = match self.state.volume_unit {
+                crate::state::VolumeUnit::Usd => crate::state::VolumeUnit::Notional,
+                crate::state::VolumeUnit::Notional => crate::state::VolumeUnit::Usd,
+            };
+            let label = match self.state.volume_unit {
+                crate::state::VolumeUnit::Usd => "USD",
+                crate::state::VolumeUnit::Notional => "Notional",
+            };
+            self.state.toast(
+                format!("Volume unit: {}", label),
+                crate::state::ToastStyle::Info,
+            );
+            self.activate_current_tab();
+            return;
+        }
+
         // Tab switching (1-6, Tab, BackTab)
         match key.code {
             KeyCode::Char(c @ '1'..='6') => {
@@ -783,6 +801,7 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
         ("Tab / Shift+Tab", "Next / previous tab"),
         ("q", "Quit"),
         ("?", "Toggle this help"),
+        ("v", "Toggle volume unit (USD / Notional)"),
         ("r", "Refresh current tab"),
         ("y", "Copy table data to clipboard (CSV)"),
         ("!", "Toggle price alert (+1% above current)"),
@@ -933,6 +952,7 @@ mod tests {
             price_flashes: std::collections::HashMap::new(),
             paper_mode: false,
             paper_engine: None,
+            volume_unit: crate::state::VolumeUnit::Usd,
             pending_navigation: None,
             instrument_types: std::collections::HashMap::new(),
         };

--- a/crates/cdcx-tui/src/app.rs
+++ b/crates/cdcx-tui/src/app.rs
@@ -1025,4 +1025,108 @@ mod tests {
             "'q' should be consumed by spotlight dismiss, not quit"
         );
     }
+
+    #[test]
+    fn test_volume_toggle_preserves_market_order() {
+        let mut app = make_app();
+        app.state.instruments = vec!["AAA_USDT".into(), "BBB_USDT".into(), "CCC_USDT".into()];
+        app.state
+            .instrument_types
+            .insert("AAA_USDT".into(), "CCY_PAIR".into());
+        app.state
+            .instrument_types
+            .insert("BBB_USDT".into(), "CCY_PAIR".into());
+        app.state
+            .instrument_types
+            .insert("CCC_USDT".into(), "CCY_PAIR".into());
+
+        app.state.tickers.insert(
+            "AAA_USDT".into(),
+            crate::state::TickerData {
+                instrument: "AAA_USDT".into(),
+                ask: 100.0,
+                bid: 99.0,
+                change_pct: 0.0,
+                high: 110.0,
+                low: 90.0,
+                volume: 1_000.0,
+                volume_usd: 100_000.0,
+                funding_rate: 0.0,
+            },
+        );
+        app.state.tickers.insert(
+            "BBB_USDT".into(),
+            crate::state::TickerData {
+                instrument: "BBB_USDT".into(),
+                ask: 200.0,
+                bid: 199.0,
+                change_pct: 0.0,
+                high: 210.0,
+                low: 190.0,
+                volume: 2_000.0,
+                volume_usd: 200_000.0,
+                funding_rate: 0.0,
+            },
+        );
+        app.state.tickers.insert(
+            "CCC_USDT".into(),
+            crate::state::TickerData {
+                instrument: "CCC_USDT".into(),
+                ask: 150.0,
+                bid: 149.0,
+                change_pct: 0.0,
+                high: 160.0,
+                low: 140.0,
+                volume: 1_500.0,
+                volume_usd: 150_000.0,
+                funding_rate: 0.0,
+            },
+        );
+
+        // Trigger refilter: enter search mode then backspace (refilter), then exit
+        app.on_key(key('/'));
+        let backspace = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
+        app.on_key(backspace);
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        app.on_key(enter);
+
+        let csv_before = app
+            .tabs
+            .get(0)
+            .and_then(|t| t.export_csv(&app.state))
+            .expect("market csv");
+        let rows_before: Vec<&str> = csv_before.lines().skip(1).collect();
+
+        app.on_key(key('v'));
+
+        let csv_after = app
+            .tabs
+            .get(0)
+            .and_then(|t| t.export_csv(&app.state))
+            .expect("market csv");
+        let rows_after: Vec<&str> = csv_after.lines().skip(1).collect();
+
+        let insts_before: Vec<&str> = rows_before
+            .iter()
+            .map(|r| r.split(',').next().unwrap())
+            .collect();
+        let insts_after: Vec<&str> = rows_after
+            .iter()
+            .map(|r| r.split(',').next().unwrap())
+            .collect();
+
+        assert_eq!(
+            insts_before, insts_after,
+            "instrument order should not change when toggling volume unit"
+        );
+
+        // prices should remain unchanged
+        for (r_before, r_after) in rows_before.iter().zip(rows_after.iter()) {
+            let cols_b: Vec<&str> = r_before.split(',').collect();
+            let cols_a: Vec<&str> = r_after.split(',').collect();
+            assert_eq!(cols_b[1], cols_a[1], "price should not change");
+            assert_eq!(cols_b[3], cols_a[3], "high should not change");
+            assert_eq!(cols_b[4], cols_a[4], "low should not change");
+        }
+    }
 }

--- a/crates/cdcx-tui/src/format.rs
+++ b/crates/cdcx-tui/src/format.rs
@@ -1,0 +1,41 @@
+pub fn format_price(price: f64) -> String {
+    if price == 0.0 {
+        return "\u{2014}".into();
+    }
+    if price >= 1000.0 {
+        let s = format!("{:.2}", price);
+        let parts: Vec<&str> = s.split('.').collect();
+        let int_part = parts[0];
+        let dec_part = parts[1];
+        let digits: Vec<char> = int_part.chars().collect();
+        let mut result = String::new();
+        for (i, &c) in digits.iter().enumerate() {
+            if i > 0 && (digits.len() - i).is_multiple_of(3) {
+                result.push(',');
+            }
+            result.push(c);
+        }
+        format!("{}.{}", result, dec_part)
+    } else if price >= 1.0 {
+        format!("{:.4}", price)
+    } else if price >= 0.01 {
+        format!("{:.6}", price)
+    } else {
+        format!("{:.8}", price)
+    }
+}
+
+pub fn format_compact(value: f64) -> String {
+    if value == 0.0 {
+        return "\u{2014}".into();
+    }
+    if value >= 1_000_000_000.0 {
+        format!("{:.1}B", value / 1_000_000_000.0)
+    } else if value >= 1_000_000.0 {
+        format!("{:.1}M", value / 1_000_000.0)
+    } else if value >= 1_000.0 {
+        format!("{:.1}K", value / 1_000.0)
+    } else {
+        format!("{:.0}", value)
+    }
+}

--- a/crates/cdcx-tui/src/lib.rs
+++ b/crates/cdcx-tui/src/lib.rs
@@ -18,13 +18,13 @@
 pub mod app;
 pub mod config;
 pub mod event;
+pub mod format;
 pub mod loading;
 pub mod setup;
 pub mod state;
 pub mod streaming;
 pub mod tabs;
 pub mod theme;
-pub mod format;
 pub mod widgets;
 pub mod workflows;
 

--- a/crates/cdcx-tui/src/lib.rs
+++ b/crates/cdcx-tui/src/lib.rs
@@ -24,6 +24,7 @@ pub mod state;
 pub mod streaming;
 pub mod tabs;
 pub mod theme;
+pub mod format;
 pub mod widgets;
 pub mod workflows;
 
@@ -216,6 +217,7 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
         price_flashes: std::collections::HashMap::new(),
         paper_mode: false,
         paper_engine: cdcx_core::paper::engine::PaperEngine::load_or_init(10000.0).ok(),
+        volume_unit: crate::state::VolumeUnit::Usd,
         pending_navigation: None,
     };
 

--- a/crates/cdcx-tui/src/state.rs
+++ b/crates/cdcx-tui/src/state.rs
@@ -89,6 +89,18 @@ pub enum AlertDirection {
     Below,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VolumeUnit {
+    Notional,
+    Usd,
+}
+
+impl Default for VolumeUnit {
+    fn default() -> Self {
+        VolumeUnit::Usd
+    }
+}
+
 pub struct AppState {
     pub instruments: Vec<String>,
     pub instrument_types: HashMap<String, String>,
@@ -110,6 +122,8 @@ pub struct AppState {
     pub price_flashes: HashMap<String, (bool, std::time::Instant)>,
     pub paper_mode: bool,
     pub paper_engine: Option<cdcx_core::paper::engine::PaperEngine>,
+    /// Volume display unit preference
+    pub volume_unit: VolumeUnit,
     /// Cross-tab navigation request: (target tab, instrument to show in detail).
     pub pending_navigation: Option<(crate::tabs::TabKind, String)>,
 }

--- a/crates/cdcx-tui/src/state.rs
+++ b/crates/cdcx-tui/src/state.rs
@@ -89,16 +89,11 @@ pub enum AlertDirection {
     Below,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VolumeUnit {
-    Notional,
+    #[default]
     Usd,
-}
-
-impl Default for VolumeUnit {
-    fn default() -> Self {
-        VolumeUnit::Usd
-    }
+    Notional,
 }
 
 pub struct AppState {

--- a/crates/cdcx-tui/src/tabs/market.rs
+++ b/crates/cdcx-tui/src/tabs/market.rs
@@ -8,6 +8,7 @@ use ratatui::Frame;
 
 use std::collections::HashMap;
 
+use crate::format::{format_compact, format_price};
 use crate::state::{AppState, RestRequest};
 use crate::tabs::{DataEvent, Tab};
 use crate::widgets::candlestick::{draw_candlestick, draw_compare_charts, Candle};
@@ -910,7 +911,10 @@ impl Tab for MarketTab {
                 Cell::from("24h"),
                 Cell::from("High"),
                 Cell::from("Low"),
-                Cell::from("Volume"),
+                Cell::from(match state.volume_unit {
+                    crate::state::VolumeUnit::Usd => "Volume (USD)",
+                    crate::state::VolumeUnit::Notional => "Volume",
+                }),
             ];
             if is_perp {
                 h.push(Cell::from("Fund"));
@@ -1023,8 +1027,11 @@ impl Tab for MarketTab {
                             .style(Style::default().fg(state.theme.colors.muted)),
                         Cell::from(format_price(t.low))
                             .style(Style::default().fg(state.theme.colors.muted)),
-                        Cell::from(format_compact(t.volume_usd))
-                            .style(Style::default().fg(state.theme.colors.volume)),
+                        Cell::from(match state.volume_unit {
+                            crate::state::VolumeUnit::Usd => format_compact(t.volume_usd),
+                            crate::state::VolumeUnit::Notional => format_compact(t.volume),
+                        })
+                        .style(Style::default().fg(state.theme.colors.volume)),
                     ];
                     if is_perp {
                         let fr_color = if t.funding_rate >= 0.0 {
@@ -1145,9 +1152,13 @@ impl Tab for MarketTab {
         let mut csv = String::from("Instrument,Price,24h%,High,Low,Volume\n");
         for inst in &self.filtered_instruments {
             if let Some(t) = state.tickers.get(inst) {
+                let vol = match state.volume_unit {
+                    crate::state::VolumeUnit::Usd => t.volume_usd,
+                    crate::state::VolumeUnit::Notional => t.volume,
+                };
                 csv.push_str(&format!(
                     "{},{:.8},{:+.2},{:.8},{:.8},{:.2}\n",
-                    inst, t.ask, t.change_pct, t.high, t.low, t.volume_usd
+                    inst, t.ask, t.change_pct, t.high, t.low, vol
                 ));
             }
         }
@@ -1166,48 +1177,7 @@ impl Tab for MarketTab {
     }
 }
 
-fn format_price(price: f64) -> String {
-    if price == 0.0 {
-        return "\u{2014}".into();
-    }
-    if price >= 1000.0 {
-        let s = format!("{:.2}", price);
-        let parts: Vec<&str> = s.split('.').collect();
-        let int_part = parts[0];
-        let dec_part = parts[1];
-        let digits: Vec<char> = int_part.chars().collect();
-        let mut result = String::new();
-        for (i, &c) in digits.iter().enumerate() {
-            if i > 0 && (digits.len() - i).is_multiple_of(3) {
-                result.push(',');
-            }
-            result.push(c);
-        }
-        format!("{}.{}", result, dec_part)
-    } else if price >= 1.0 {
-        format!("{:.4}", price)
-    } else if price >= 0.01 {
-        format!("{:.6}", price)
-    } else {
-        format!("{:.8}", price)
-    }
-}
-
-fn format_compact(value: f64) -> String {
-    if value == 0.0 {
-        return "\u{2014}".into();
-    }
-    if value >= 1_000_000_000.0 {
-        format!("{:.1}B", value / 1_000_000_000.0)
-    } else if value >= 1_000_000.0 {
-        format!("{:.1}M", value / 1_000_000.0)
-    } else if value >= 1_000.0 {
-        format!("{:.1}K", value / 1_000.0)
-    } else {
-        format!("{:.0}", value)
-    }
-}
-
+// format helpers moved to crate::format
 /// Sparkline using Braille dot patterns for smooth line rendering.
 /// Each character cell is 2 dots wide × 4 dots high, giving much higher
 /// resolution than block characters.

--- a/crates/cdcx-tui/src/tabs/watchlist.rs
+++ b/crates/cdcx-tui/src/tabs/watchlist.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Paragraph, Row, Table};
 use ratatui::Frame;
 
+use crate::format::{format_compact, format_price};
 use crate::state::AppState;
 use crate::tabs::{DataEvent, Tab, TabKind};
 use crate::widgets::instrument_picker::{InstrumentPicker, PickerResult};
@@ -118,7 +119,10 @@ impl Tab for WatchlistTab {
             Cell::from("24h"),
             Cell::from("High"),
             Cell::from("Low"),
-            Cell::from("Volume"),
+            Cell::from(match state.volume_unit {
+                crate::state::VolumeUnit::Usd => "Volume (USD)",
+                crate::state::VolumeUnit::Notional => "Volume",
+            }),
         ])
         .style(
             Style::default()
@@ -159,15 +163,18 @@ impl Tab for WatchlistTab {
                     };
                     Row::new(vec![
                         Cell::from(inst.as_str()),
-                        Cell::from(format!("{:.2}", t.ask)),
+                        Cell::from(format_price(t.ask)),
                         Cell::from(format!("{:+.2}%", t.change_pct * 100.0))
                             .style(Style::default().fg(change_color)),
-                        Cell::from(format!("{:.2}", t.high))
+                        Cell::from(format_price(t.high))
                             .style(Style::default().fg(state.theme.colors.muted)),
-                        Cell::from(format!("{:.2}", t.low))
+                        Cell::from(format_price(t.low))
                             .style(Style::default().fg(state.theme.colors.muted)),
-                        Cell::from(format!("{:.0}", t.volume))
-                            .style(Style::default().fg(state.theme.colors.volume)),
+                        Cell::from(match state.volume_unit {
+                            crate::state::VolumeUnit::Usd => format_compact(t.volume_usd),
+                            crate::state::VolumeUnit::Notional => format_compact(t.volume),
+                        })
+                        .style(Style::default().fg(state.theme.colors.volume)),
                     ])
                     .style(row_style)
                 } else {

--- a/crates/cdcx-tui/src/widgets/status_bar.rs
+++ b/crates/cdcx-tui/src/widgets/status_bar.rs
@@ -115,7 +115,7 @@ pub fn draw_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
         ));
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
-            "q:quit  Tab:switch  ,:settings  ?:help",
+            "q:quit  Tab:switch  v:volume unit  ,:settings  ?:help",
             Style::default().fg(state.theme.colors.muted),
         ));
     }


### PR DESCRIPTION
- Move price/volume formatting helpers to format.rs and reuse in Market/Watchlist.
- Apply format_price to price/high/low and format_compact to volumes.
- Add VolumeUnit state and global 'v' toggle (USD / Notional); update status bar and help.
- Preserve market sort order when toggling display unit.
- Tests: cdcx-tui tests pass locally.