### PR TITLE
feat: isolated margin workflow, rejection-aware modals, close-position, and client_oid origin tagging

### DIFF
--- a/crates/cdcx-cli/src/dispatch.rs
+++ b/crates/cdcx-cli/src/dispatch.rs
@@ -147,18 +147,30 @@ pub async fn dispatch_dynamic(
     // Extract params from ArgMatches using schema types
     let mut params = cli_builder::extract_params(cmd_matches, &endpoint.params);
 
-    // Auto-generate client_oid for create-order if not provided (prevents DUPLICATE_CLORDID)
-    if endpoint.method == "private/create-order"
-        || endpoint.method == "private/advanced/create-order"
-    {
-        if let Some(obj) = params.as_object_mut() {
-            if !obj.contains_key("client_oid") {
-                let ts = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis();
-                obj.insert("client_oid".to_string(), serde_json::json!(ts.to_string()));
+    // Stamp client_oid with the cx1- CLI origin prefix so orders placed via `cdcx`
+    // are identifiable downstream. Both create-order and advanced/create-order use
+    // a scalar client_oid; create-order-list puts client_oid on each leg.
+    // See cdcx-core::origin for the prefix scheme.
+    use cdcx_core::origin::{tag_order_list_legs, tag_params_in_place, OriginChannel};
+    let is_single_order = endpoint.method == "private/create-order"
+        || endpoint.method == "private/advanced/create-order";
+    let is_order_list = endpoint.method == "private/create-order-list"
+        || endpoint.method == "private/create-oco-order"
+        || endpoint.method == "private/create-oto-order"
+        || endpoint.method == "private/create-otoco-order";
+    if is_single_order {
+        if let Some(tagged) = tag_params_in_place(&mut params, OriginChannel::Cli) {
+            if tagged.truncated {
+                eprintln!("warning: client_oid truncated to fit 36-char limit after cdcx prefix");
             }
+        }
+    } else if is_order_list {
+        let truncations = tag_order_list_legs(&mut params, OriginChannel::Cli);
+        if truncations > 0 {
+            eprintln!(
+                "warning: {} client_oid leg(s) truncated to fit 36-char limit after cdcx prefix",
+                truncations
+            );
         }
     }
 

--- a/crates/cdcx-cli/src/mcp/server.rs
+++ b/crates/cdcx-cli/src/mcp/server.rs
@@ -135,7 +135,24 @@ impl rmcp::handler::server::ServerHandler for CdcxMcpServer {
                     }
                 }
             }
-            let params_value = serde_json::Value::Object(params);
+            let mut params_value = serde_json::Value::Object(params);
+
+            // Stamp cx2- MCP origin prefix on order-creating payloads so orders placed
+            // by AI agents are distinguishable from CLI/TUI flow in exchange databases.
+            // See cdcx-core::origin for the scheme.
+            {
+                use cdcx_core::origin::{tag_order_list_legs, tag_params_in_place, OriginChannel};
+                let method = endpoint.method.as_str();
+                if method == "private/create-order" || method == "private/advanced/create-order" {
+                    let _ = tag_params_in_place(&mut params_value, OriginChannel::Mcp);
+                } else if method == "private/create-order-list"
+                    || method == "private/create-oco-order"
+                    || method == "private/create-oto-order"
+                    || method == "private/create-otoco-order"
+                {
+                    tag_order_list_legs(&mut params_value, OriginChannel::Mcp);
+                }
+            }
 
             // Validate params against adversarial input patterns
             cdcx_core::sanitize::validate_json_payload(&params_value).map_err(|e| {

--- a/crates/cdcx-core/src/lib.rs
+++ b/crates/cdcx-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod env;
 pub mod error;
 pub mod openapi;
+pub mod origin;
 pub mod output;
 pub mod paper;
 pub mod safety;

--- a/crates/cdcx-core/src/origin.rs
+++ b/crates/cdcx-core/src/origin.rs
@@ -1,0 +1,347 @@
+//! Origin-tagging for `client_oid` so orders placed via cdcx tooling are identifiable
+//! in exchange-side databases. The exchange persists `client_oid` / `cl_order_id`
+//! across its Postgres/ClickHouse/Cassandra stores, so a consistent 4-char prefix
+//! lets operators bucket volume by channel with a simple `LEFT(cl_order_id, 3)`.
+//!
+//! # Prefix scheme
+//!
+//! | Channel | Prefix |
+//! |---------|--------|
+//! | CLI (`cdcx trade order ...`)       | `cx1-` |
+//! | MCP server (AI agent tools)         | `cx2-` |
+//! | TUI dashboard workflows             | `cx3-` |
+//!
+//! # Length constraint
+//!
+//! The exchange enforces a 36-char limit on `client_oid`. The prefix is always 4
+//! chars, so the user's own ID (or auto-generated suffix) gets 32 chars of room.
+//! User-supplied IDs are truncated to fit; callers can inspect the returned struct
+//! to warn when truncation occurred.
+//!
+//! # Opt-out
+//!
+//! Setting `CDCX_NO_ORIGIN_TAG=1` disables tagging entirely. Intentionally undocumented
+//! for external users — it exists for power users with pre-existing ID schemes that
+//! must survive the round trip verbatim.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Monotonic counter so two calls within the same millisecond still produce distinct
+/// suffixes. Stack addresses are not reliable entropy — the compiler may reuse them
+/// across successive calls in a tight loop.
+static SUFFIX_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Maximum accepted length of `client_oid` on the Crypto.com Exchange.
+pub const MAX_CLIENT_OID_LEN: usize = 36;
+
+/// Which surface of the cdcx tooling submitted this order. Determines the 3-char
+/// origin code in the prefix (`cx1`/`cx2`/`cx3`).
+///
+/// Adding a new channel will produce compile errors at every call site, forcing
+/// them to declare their origin — no silent "forgot to tag that one" bugs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OriginChannel {
+    Cli,
+    Mcp,
+    Tui,
+}
+
+impl OriginChannel {
+    /// The 4-char prefix written to `client_oid`, including the trailing hyphen.
+    pub fn prefix(self) -> &'static str {
+        match self {
+            OriginChannel::Cli => "cx1-",
+            OriginChannel::Mcp => "cx2-",
+            OriginChannel::Tui => "cx3-",
+        }
+    }
+}
+
+/// Result of tagging an existing-or-absent `client_oid`. `truncated` tells callers
+/// whether the user-supplied tail had to be shortened to fit the 36-char limit —
+/// useful for stderr warnings in the CLI or toast notifications in the TUI.
+#[derive(Debug, Clone)]
+pub struct TaggedClientOid {
+    pub value: String,
+    pub truncated: bool,
+}
+
+/// Returns `true` when the caller has opted out of tagging via `CDCX_NO_ORIGIN_TAG=1`.
+/// Any truthy value (`1`, `true`, `yes`) disables tagging; empty/unset/`0`/`false` do not.
+fn opt_out() -> bool {
+    match std::env::var("CDCX_NO_ORIGIN_TAG") {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => false,
+    }
+}
+
+/// Generate a ULID-ish time-ordered suffix, of exactly `len` chars. Uses crockford
+/// base32 alphabet for friendliness and avoids characters that look alike (O/0, I/1).
+/// The leading chars encode milliseconds since epoch, so sorting by `client_oid`
+/// approximates chronological order — keeps Cassandra partition scans index-friendly.
+fn generate_suffix(len: usize) -> String {
+    const ALPHABET: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+
+    let mut buf = String::with_capacity(len);
+    // Encode 48 bits of timestamp (enough through year 10889) into the first 10 chars
+    // when space permits; remainder filled with pseudo-random base32 chars.
+    let ts_chars = len.min(10);
+    let mut ts = millis as u64;
+    let mut ts_encoded = Vec::with_capacity(ts_chars);
+    for _ in 0..ts_chars {
+        ts_encoded.push(ALPHABET[(ts & 0x1f) as usize]);
+        ts >>= 5;
+    }
+    ts_encoded.reverse();
+    for byte in ts_encoded {
+        buf.push(byte as char);
+    }
+
+    if buf.len() < len {
+        // Fill remainder with entropy from the monotonic counter + millis. Uniqueness
+        // is what matters here, not unpredictability — an adversary cannot derive
+        // anything damaging from the suffix, and same-millisecond calls are handled
+        // by the counter regardless of how fast the machine is.
+        let counter = SUFFIX_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut seed = (millis as u64) ^ counter.rotate_left(17) ^ 0x9E3779B97F4A7C15;
+        while buf.len() < len {
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            buf.push(ALPHABET[((seed >> 33) & 0x1f) as usize] as char);
+        }
+    }
+
+    buf
+}
+
+/// Tag a `client_oid` with the origin prefix. The returned string is guaranteed to be
+/// ≤ 36 chars. If `existing` is provided, it's truncated to fit after the prefix; if
+/// absent, a ULID-ish time-ordered suffix is generated.
+///
+/// Returns the original `existing` verbatim (or a generated suffix without prefix)
+/// when the `CDCX_NO_ORIGIN_TAG` opt-out is active.
+pub fn tag_client_oid(existing: Option<&str>, channel: OriginChannel) -> TaggedClientOid {
+    if opt_out() {
+        return TaggedClientOid {
+            value: existing
+                .map(|s| s.chars().take(MAX_CLIENT_OID_LEN).collect())
+                .unwrap_or_else(|| generate_suffix(MAX_CLIENT_OID_LEN)),
+            truncated: existing.is_some_and(|s| s.len() > MAX_CLIENT_OID_LEN),
+        };
+    }
+    let prefix = channel.prefix();
+    let budget = MAX_CLIENT_OID_LEN - prefix.len();
+    match existing {
+        Some(user) => {
+            // If the user already tagged the ID themselves (e.g. replayed through cdcx
+            // a second time, or the TUI handing to the same helper twice), leave it
+            // alone so we never double-prefix cx1-cx1-...
+            if user.starts_with("cx1-") || user.starts_with("cx2-") || user.starts_with("cx3-") {
+                let truncated = user.len() > MAX_CLIENT_OID_LEN;
+                return TaggedClientOid {
+                    value: user.chars().take(MAX_CLIENT_OID_LEN).collect(),
+                    truncated,
+                };
+            }
+            let truncated = user.len() > budget;
+            let tail: String = user.chars().take(budget).collect();
+            TaggedClientOid {
+                value: format!("{}{}", prefix, tail),
+                truncated,
+            }
+        }
+        None => TaggedClientOid {
+            value: format!("{}{}", prefix, generate_suffix(budget)),
+            truncated: false,
+        },
+    }
+}
+
+/// Tag every leg in an OCO / OTOCO `order_list` array under a `params` object.
+/// No-op if the object doesn't contain `order_list` or it isn't an array. Returns
+/// the count of legs that had their `client_oid` truncated, so callers can warn once.
+pub fn tag_order_list_legs(params: &mut serde_json::Value, channel: OriginChannel) -> usize {
+    let mut truncations = 0;
+    let Some(obj) = params.as_object_mut() else {
+        return 0;
+    };
+    let Some(list) = obj.get_mut("order_list").and_then(|v| v.as_array_mut()) else {
+        return 0;
+    };
+    for leg in list.iter_mut() {
+        let Some(leg_obj) = leg.as_object_mut() else {
+            continue;
+        };
+        let existing = leg_obj
+            .get("client_oid")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let tagged = tag_client_oid(existing.as_deref(), channel);
+        if tagged.truncated {
+            truncations += 1;
+        }
+        leg_obj.insert("client_oid".into(), serde_json::Value::String(tagged.value));
+    }
+    truncations
+}
+
+/// Tag the top-level `client_oid` on a `create-order` / `create-order-list` / etc.
+/// payload in place. Returns the tagged `client_oid` so callers can surface it (e.g.
+/// print it to stderr after placement). A `None` return means the opt-out was active
+/// and the field was left untouched when absent, or returned verbatim when present.
+pub fn tag_params_in_place(
+    params: &mut serde_json::Value,
+    channel: OriginChannel,
+) -> Option<TaggedClientOid> {
+    let obj = params.as_object_mut()?;
+    let existing = obj
+        .get("client_oid")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let tagged = tag_client_oid(existing.as_deref(), channel);
+    obj.insert(
+        "client_oid".into(),
+        serde_json::Value::String(tagged.value.clone()),
+    );
+    Some(tagged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serialize env-var mutation across parallel tests. `#[test]`s run on multiple
+    /// threads in one process; without this lock, `CDCX_NO_ORIGIN_TAG` flips under
+    /// our feet and causes flaky assertions.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Execute `f` with `CDCX_NO_ORIGIN_TAG` temporarily unset, so tests are not
+    /// influenced by the developer's local env.
+    fn with_tagging_enabled<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("CDCX_NO_ORIGIN_TAG").ok();
+        std::env::remove_var("CDCX_NO_ORIGIN_TAG");
+        let out = f();
+        if let Some(v) = prev {
+            std::env::set_var("CDCX_NO_ORIGIN_TAG", v);
+        }
+        out
+    }
+
+    #[test]
+    fn prefix_is_four_chars_with_hyphen() {
+        assert_eq!(OriginChannel::Cli.prefix(), "cx1-");
+        assert_eq!(OriginChannel::Mcp.prefix(), "cx2-");
+        assert_eq!(OriginChannel::Tui.prefix(), "cx3-");
+        for ch in [OriginChannel::Cli, OriginChannel::Mcp, OriginChannel::Tui] {
+            assert_eq!(ch.prefix().len(), 4);
+            assert!(ch.prefix().ends_with('-'));
+        }
+    }
+
+    #[test]
+    fn autogenerated_oid_respects_limit() {
+        with_tagging_enabled(|| {
+            let tagged = tag_client_oid(None, OriginChannel::Cli);
+            assert!(tagged.value.starts_with("cx1-"));
+            assert_eq!(tagged.value.len(), MAX_CLIENT_OID_LEN);
+            assert!(!tagged.truncated);
+        });
+    }
+
+    #[test]
+    fn user_oid_gets_prefixed() {
+        with_tagging_enabled(|| {
+            let tagged = tag_client_oid(Some("my-ladder-3"), OriginChannel::Cli);
+            assert_eq!(tagged.value, "cx1-my-ladder-3");
+            assert!(!tagged.truncated);
+        });
+    }
+
+    #[test]
+    fn overlong_user_oid_is_truncated_prefix_preserved() {
+        with_tagging_enabled(|| {
+            let long = "a".repeat(100);
+            let tagged = tag_client_oid(Some(&long), OriginChannel::Tui);
+            assert!(tagged.value.starts_with("cx3-"));
+            assert_eq!(tagged.value.len(), MAX_CLIENT_OID_LEN);
+            assert!(tagged.truncated);
+        });
+    }
+
+    #[test]
+    fn already_tagged_oid_not_double_prefixed() {
+        with_tagging_enabled(|| {
+            let tagged = tag_client_oid(Some("cx1-pre-existing-id"), OriginChannel::Mcp);
+            // Keep the original tag — do not wrap cx2-cx1-...
+            assert_eq!(tagged.value, "cx1-pre-existing-id");
+        });
+    }
+
+    #[test]
+    fn opt_out_env_var_suppresses_prefix() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("CDCX_NO_ORIGIN_TAG", "1");
+        let tagged = tag_client_oid(Some("plain-id"), OriginChannel::Cli);
+        assert_eq!(tagged.value, "plain-id");
+        std::env::remove_var("CDCX_NO_ORIGIN_TAG");
+    }
+
+    #[test]
+    fn tag_params_in_place_adds_client_oid_when_absent() {
+        with_tagging_enabled(|| {
+            let mut params = serde_json::json!({"side": "BUY"});
+            let tagged = tag_params_in_place(&mut params, OriginChannel::Mcp).unwrap();
+            assert!(tagged.value.starts_with("cx2-"));
+            assert_eq!(
+                params["client_oid"],
+                serde_json::Value::String(tagged.value)
+            );
+        });
+    }
+
+    #[test]
+    fn tag_order_list_legs_tags_each_leg() {
+        with_tagging_enabled(|| {
+            let mut params = serde_json::json!({
+                "contingency_type": "OCO",
+                "order_list": [
+                    {"side": "SELL", "client_oid": "leg-a"},
+                    {"side": "SELL"},
+                ]
+            });
+            let truncations = tag_order_list_legs(&mut params, OriginChannel::Tui);
+            assert_eq!(truncations, 0);
+            let list = params["order_list"].as_array().unwrap();
+            assert_eq!(
+                list[0]["client_oid"],
+                serde_json::Value::String("cx3-leg-a".into())
+            );
+            let generated = list[1]["client_oid"].as_str().unwrap();
+            assert!(generated.starts_with("cx3-"));
+            assert_eq!(generated.len(), MAX_CLIENT_OID_LEN);
+        });
+    }
+
+    #[test]
+    fn generated_suffixes_are_unique_across_rapid_calls() {
+        with_tagging_enabled(|| {
+            let a = tag_client_oid(None, OriginChannel::Cli).value;
+            let b = tag_client_oid(None, OriginChannel::Cli).value;
+            let c = tag_client_oid(None, OriginChannel::Cli).value;
+            assert_ne!(a, b);
+            assert_ne!(b, c);
+            assert_ne!(a, c);
+        });
+    }
+}

--- a/crates/cdcx-tui/src/app.rs
+++ b/crates/cdcx-tui/src/app.rs
@@ -16,6 +16,7 @@ use crate::tabs::{DataEvent, Tab, TabKind};
 use crate::widgets::settings::{SettingsAction, SettingsPanel};
 use crate::widgets::status_bar::draw_status_bar;
 use crate::workflows::cancel_order::CancelOrderWorkflow;
+use crate::workflows::close_position::ClosePositionWorkflow;
 use crate::workflows::oco_order::OcoOrderWorkflow;
 use crate::workflows::otoco_order::OtocoOrderWorkflow;
 use crate::workflows::paper_order::PaperOrderWorkflow;
@@ -372,16 +373,50 @@ impl App {
         // Workflow triggers only if the tab didn't consume the key
         let tab_kind = TabKind::ALL.get(self.active_tab).copied();
         match (tab_kind, key.code) {
-            (Some(TabKind::Market), KeyCode::Char('t')) => {
+            (
+                Some(TabKind::Market) | Some(TabKind::Positions) | Some(TabKind::Watchlist),
+                KeyCode::Char('t'),
+            ) => {
                 let instrument = self.get_selected_instrument().unwrap_or("BTC_USDT".into());
                 if self.state.paper_mode {
                     self.workflow = Some(Box::new(PaperOrderWorkflow::new(instrument)));
                 } else {
-                    self.workflow = Some(Box::new(PlaceOrderWorkflow::new(instrument)));
+                    self.workflow =
+                        Some(Box::new(PlaceOrderWorkflow::new(instrument, &self.state)));
                 }
                 self.mode = Mode::Workflow;
             }
-            (Some(TabKind::Market) | Some(TabKind::Orders), KeyCode::Char('c')) => {
+            (Some(TabKind::Positions), KeyCode::Char('x')) => {
+                // Close position — only on the Positions tab. Requires an open
+                // position on the selected row; if the snapshot is empty we surface
+                // a toast rather than spawning a half-formed modal.
+                if self.state.paper_mode {
+                    self.state.toast(
+                        "Close-position workflow not available in paper mode",
+                        crate::state::ToastStyle::Info,
+                    );
+                } else if let Some(instrument) = self.get_selected_instrument() {
+                    match ClosePositionWorkflow::new(instrument.clone(), &self.state) {
+                        Some(wf) => {
+                            self.workflow = Some(Box::new(wf));
+                            self.mode = Mode::Workflow;
+                        }
+                        None => {
+                            self.state.toast(
+                                format!("No open position for {}", instrument),
+                                crate::state::ToastStyle::Info,
+                            );
+                        }
+                    }
+                }
+            }
+            (
+                Some(TabKind::Market)
+                | Some(TabKind::Orders)
+                | Some(TabKind::Positions)
+                | Some(TabKind::Watchlist),
+                KeyCode::Char('c'),
+            ) => {
                 if self.state.paper_mode {
                     // Cancel first open paper order for selected instrument
                     let inst = self.get_selected_instrument().unwrap_or("BTC_USDT".into());
@@ -412,12 +447,27 @@ impl App {
                         );
                     }
                 } else {
-                    let instrument = self.get_selected_instrument().unwrap_or("BTC_USDT".into());
-                    self.workflow = Some(Box::new(CancelOrderWorkflow::new(instrument)));
-                    self.mode = Mode::Workflow;
+                    // No BTC_USDT fallback — cancelling the wrong instrument is worse
+                    // than refusing. If the tab has no selection (empty list, or a tab
+                    // without instrument semantics), tell the user rather than guessing.
+                    match self.get_selected_instrument() {
+                        Some(instrument) => {
+                            self.workflow = Some(Box::new(CancelOrderWorkflow::new(instrument)));
+                            self.mode = Mode::Workflow;
+                        }
+                        None => {
+                            self.state.toast(
+                                "No instrument selected — pick a row first",
+                                crate::state::ToastStyle::Info,
+                            );
+                        }
+                    }
                 }
             }
-            (Some(TabKind::Market), KeyCode::Char('o')) => {
+            (
+                Some(TabKind::Market) | Some(TabKind::Positions) | Some(TabKind::Watchlist),
+                KeyCode::Char('o'),
+            ) => {
                 if self.state.paper_mode {
                     self.state.toast(
                         "OCO orders not available in paper mode",
@@ -429,7 +479,10 @@ impl App {
                     self.mode = Mode::Workflow;
                 }
             }
-            (Some(TabKind::Market), KeyCode::Char('O')) => {
+            (
+                Some(TabKind::Market) | Some(TabKind::Positions) | Some(TabKind::Watchlist),
+                KeyCode::Char('O'),
+            ) => {
                 if self.state.paper_mode {
                     self.state.toast(
                         "OTOCO orders not available in paper mode",
@@ -442,6 +495,56 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Recalculate portfolio total from a balance records array (WS or REST shape).
+    /// Mirrors the logic used by `private/user-balance` REST handling so WS pushes keep
+    /// the status-bar portfolio value in sync without waiting for the 30s REST tick.
+    fn apply_balance_records(&mut self, items: &[serde_json::Value]) {
+        if self.state.paper_mode {
+            return;
+        }
+        let mut total = 0.0;
+        for item in items {
+            let currency = item
+                .get("instrument_name")
+                .or_else(|| item.get("currency"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            let amount: f64 = item
+                .get("total_cash_balance")
+                .or_else(|| item.get("quantity"))
+                .or_else(|| item.get("balance"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0);
+            if amount <= 0.0 {
+                continue;
+            }
+            let value: f64 = item
+                .get("market_value")
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| {
+                    if matches!(currency, "USDT" | "USD" | "USDC" | "DAI" | "TUSD" | "BUSD") {
+                        amount
+                    } else {
+                        let pair = format!("{}_USDT", currency);
+                        self.state
+                            .tickers
+                            .get(&pair)
+                            .map(|t| amount * t.ask)
+                            .unwrap_or(0.0)
+                    }
+                });
+            total += value;
+        }
+        if total > 0.0 {
+            if self.state.session_start_value.is_none() {
+                self.state.session_start_value = Some(total);
+            }
+            self.state.current_portfolio_value = total;
         }
     }
 
@@ -462,81 +565,82 @@ impl App {
                 .insert(ticker.instrument.clone(), ticker.clone());
         }
 
-        // Track live portfolio value for status bar from any tab
+        // Keep isolated_positions + portfolio value fresh from WS user channels.
+        if let DataEvent::PositionsSnapshot(ref positions) = event {
+            self.state.update_positions(positions);
+        }
+        if let DataEvent::BalanceSnapshot(ref balances) = event {
+            self.apply_balance_records(balances);
+        }
+
+        // Track live portfolio value for status bar from REST responses too.
         if let DataEvent::RestResponse {
             ref method,
             ref data,
         } = event
         {
-            if method == "private/user-balance" && !self.state.paper_mode {
+            if method == "private/user-balance" {
                 if let Some(arr) = data.get("data").and_then(|d| d.as_array()) {
-                    let mut total = 0.0;
-                    for item in arr {
-                        let currency = item
-                            .get("instrument_name")
-                            .or_else(|| item.get("currency"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("?");
-                        let amount: f64 = item
-                            .get("total_cash_balance")
-                            .or_else(|| item.get("quantity"))
-                            .or_else(|| item.get("balance"))
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse().ok())
-                            .unwrap_or(0.0);
-                        if amount <= 0.0 {
-                            continue;
-                        }
-                        let value: f64 = item
-                            .get("market_value")
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse().ok())
-                            .unwrap_or_else(|| {
-                                if matches!(
-                                    currency,
-                                    "USDT" | "USD" | "USDC" | "DAI" | "TUSD" | "BUSD"
-                                ) {
-                                    amount
-                                } else {
-                                    let pair = format!("{}_USDT", currency);
-                                    self.state
-                                        .tickers
-                                        .get(&pair)
-                                        .map(|t| amount * t.ask)
-                                        .unwrap_or(0.0)
-                                }
-                            });
-                        total += value;
-                    }
-                    if total > 0.0 {
-                        if self.state.session_start_value.is_none() {
-                            self.state.session_start_value = Some(total);
-                        }
-                        self.state.current_portfolio_value = total;
-                    }
+                    self.apply_balance_records(arr);
+                }
+            }
+            if method == "private/get-positions" {
+                if let Some(arr) = data.get("data").and_then(|d| d.as_array()) {
+                    self.state.update_positions(arr);
                 }
             }
         }
 
-        // REST responses for workflows (create-order, cancel-all-orders)
+        // REST responses for workflows (create-order, cancel-all-orders).
+        // The API client returns Ok(...) with embedded code+message for business-logic
+        // rejections (api_client.rs parse_response), so we MUST inspect the body —
+        // blindly closing the modal would silently swallow errors like
+        // INSTRUMENT_MUST_USE_ISOLATED_MARGIN.
         if let DataEvent::RestResponse {
             ref method,
-            data: _,
+            ref data,
         } = event
         {
             if self.mode == Mode::Workflow {
                 if method == "private/create-order" {
-                    self.workflow = None;
-                    self.mode = Mode::Normal;
-                    self.state
-                        .toast("Order submitted", crate::state::ToastStyle::Success);
+                    if let Some(ref mut wf) = self.workflow {
+                        match wf.on_response(method, data, &mut self.state) {
+                            WorkflowResult::Done | WorkflowResult::Cancel => {
+                                self.workflow = None;
+                                self.mode = Mode::Normal;
+                            }
+                            WorkflowResult::Continue => {
+                                // Workflow keeps the modal open (e.g. to show rejection).
+                            }
+                        }
+                    }
                     return;
                 }
                 if method == "private/cancel-all-orders" {
+                    let code = data
+                        .get("data")
+                        .and_then(|d| d.get("code"))
+                        .and_then(|v| v.as_i64())
+                        .or_else(|| data.get("code").and_then(|v| v.as_i64()))
+                        .unwrap_or(0);
                     self.workflow = None;
                     self.mode = Mode::Normal;
-                    self.state
-                        .toast("Orders cancelled", crate::state::ToastStyle::Success);
+                    if code == 0 {
+                        self.state
+                            .toast("Orders cancelled", crate::state::ToastStyle::Success);
+                    } else {
+                        let message = data
+                            .get("data")
+                            .and_then(|d| d.get("message"))
+                            .or_else(|| data.get("message"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("Cancel rejected")
+                            .to_string();
+                        self.state.toast(
+                            format!("[{}] {}", code, message),
+                            crate::state::ToastStyle::Error,
+                        );
+                    }
                     return;
                 }
             }
@@ -801,10 +905,11 @@ fn draw_help_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
         ("h", "Toggle heatmap mode"),
         ("k", "Candlestick chart (streaming)"),
         ("m", "Compare charts (up to 4)"),
-        ("t", "Place order"),
+        ("t", "Place order (Market/Positions/Watchlist)"),
         ("o", "OCO order (stop-loss + take-profit)"),
         ("O", "OTOCO order (entry + SL + TP)"),
         ("c", "Cancel orders"),
+        ("x", "Close position (Positions tab only)"),
         ("p", "Toggle LIVE / PAPER mode"),
         ("", ""),
         ("Detail View", ""),
@@ -935,6 +1040,9 @@ mod tests {
             paper_engine: None,
             pending_navigation: None,
             instrument_types: std::collections::HashMap::new(),
+            user_connection: crate::state::ConnectionStatus::Error,
+            isolated_positions: std::collections::HashMap::new(),
+            positions_snapshot: Vec::new(),
         };
         let mut app = App::new(state, &[]);
         // Seed market tab with an instrument so workflow triggers have something to select

--- a/crates/cdcx-tui/src/lib.rs
+++ b/crates/cdcx-tui/src/lib.rs
@@ -87,7 +87,7 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
     let credentials = Credentials::resolve(cdcx_config.as_ref(), opts.profile.as_deref()).ok();
     let authenticated = credentials.is_some();
-    let api = Arc::new(ApiClient::new(credentials, opts.env));
+    let api = Arc::new(ApiClient::new(credentials.clone(), opts.env));
 
     // Enter terminal immediately for the loading screen
     let mut terminal = ratatui::init();
@@ -207,6 +207,11 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
         theme,
         terminal_size: crossterm::terminal::size().unwrap_or((80, 24)),
         market_connection: ConnectionStatus::Connecting,
+        user_connection: if authenticated {
+            ConnectionStatus::Connecting
+        } else {
+            ConnectionStatus::Error
+        },
         api: api.clone(),
         rest_tx: rest_req_tx,
         toast: None,
@@ -217,6 +222,8 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
         paper_mode: false,
         paper_engine: cdcx_core::paper::engine::PaperEngine::load_or_init(10000.0).ok(),
         pending_navigation: None,
+        isolated_positions: std::collections::HashMap::new(),
+        positions_snapshot: Vec::new(),
     };
 
     let watchlist = config.watchlist.clone();
@@ -230,7 +237,26 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
 
     // Stream manager for real-time WebSocket data
     let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel();
-    let stream_mgr = StreamManager::spawn(opts.env, stream_tx);
+    let stream_mgr = StreamManager::spawn(opts.env, stream_tx.clone());
+
+    // User-channel stream for authenticated account data (positions, balance, orders).
+    // Kept always-on while authenticated so isolated_positions stays current across
+    // tabs — the place-order workflow needs it to auto-attach isolation_id on orders
+    // against existing isolated positions (error 617 otherwise).
+    let user_stream_mgr = if let Some(creds) = credentials {
+        Some(streaming::UserStreamManager::spawn(
+            opts.env,
+            creds,
+            vec![
+                "user.positions".into(),
+                "user.balance".into(),
+                "user.order".into(),
+            ],
+            stream_tx,
+        ))
+    } else {
+        None
+    };
 
     // Initial subscriptions based on active tab
     let mut last_subs = app.active_subscriptions();
@@ -360,6 +386,15 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
                         streaming::StreamEvent::TradeUpdate(val) => {
                             app.on_data(DataEvent::TradeSnapshot(val));
                         }
+                        streaming::StreamEvent::PositionsUpdate(positions) => {
+                            app.on_data(DataEvent::PositionsSnapshot(positions));
+                        }
+                        streaming::StreamEvent::BalanceUpdate(balances) => {
+                            app.on_data(DataEvent::BalanceSnapshot(balances));
+                        }
+                        streaming::StreamEvent::OrdersUpdate(orders) => {
+                            app.on_data(DataEvent::OrdersUpdate(orders));
+                        }
                         streaming::StreamEvent::ConnectionStatus(cs) => {
                             match cs {
                                 streaming::ConnectionStatusEvent::MarketConnected => {
@@ -375,6 +410,21 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
                                 streaming::ConnectionStatusEvent::MarketError(_) => {
                                     app.state.toast("Connection lost", state::ToastStyle::Error);
                                     app.state.market_connection = ConnectionStatus::Error;
+                                }
+                                streaming::ConnectionStatusEvent::UserConnected => {
+                                    if app.state.user_connection != ConnectionStatus::Connected {
+                                        app.state.toast(
+                                            "User stream connected",
+                                            state::ToastStyle::Success,
+                                        );
+                                    }
+                                    app.state.user_connection = ConnectionStatus::Connected;
+                                }
+                                streaming::ConnectionStatusEvent::UserReconnecting => {
+                                    app.state.user_connection = ConnectionStatus::Reconnecting;
+                                }
+                                streaming::ConnectionStatusEvent::UserError(_) => {
+                                    app.state.user_connection = ConnectionStatus::Error;
                                 }
                             }
                         }
@@ -402,6 +452,9 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     stream_mgr.shutdown();
+    if let Some(ref u) = user_stream_mgr {
+        u.shutdown();
+    }
     crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture).ok();
     ratatui::restore();
     Ok(())

--- a/crates/cdcx-tui/src/state.rs
+++ b/crates/cdcx-tui/src/state.rs
@@ -100,6 +100,7 @@ pub struct AppState {
     pub theme: Theme,
     pub terminal_size: (u16, u16),
     pub market_connection: ConnectionStatus,
+    pub user_connection: ConnectionStatus,
     pub api: Arc<ApiClient>,
     pub rest_tx: mpsc::UnboundedSender<RestRequest>,
     pub toast: Option<Toast>,
@@ -112,6 +113,13 @@ pub struct AppState {
     pub paper_engine: Option<cdcx_core::paper::engine::PaperEngine>,
     /// Cross-tab navigation request: (target tab, instrument to show in detail).
     pub pending_navigation: Option<(crate::tabs::TabKind, String)>,
+    /// instrument_name → isolation_id for currently-open isolated-margin positions.
+    /// Populated from `user.positions` WS channel + `private/get-positions` REST responses.
+    /// Required to add to / trim an existing isolated position without triggering error 617.
+    pub isolated_positions: HashMap<String, String>,
+    /// Latest snapshot of all open positions (any margin type). Source of truth for
+    /// the Positions tab and the isolated_positions cache. Updated via WS pushes.
+    pub positions_snapshot: Vec<serde_json::Value>,
 }
 
 impl AppState {
@@ -172,6 +180,42 @@ impl AppState {
             }
         }
     }
+    /// Refresh positions cache and derived isolated_positions lookup from an array of
+    /// position records (either WS `user.positions` data or REST `private/get-positions`).
+    /// Keeps ISOLATED_MARGIN bucket ids indexed by instrument_name so the place-order
+    /// workflow can auto-attach `isolation_id` to subsequent orders on the same instrument.
+    pub fn update_positions(&mut self, positions: &[serde_json::Value]) {
+        self.positions_snapshot = positions.to_vec();
+        let mut isolated = HashMap::new();
+        for pos in positions {
+            let is_isolated = pos
+                .get("isolation_type")
+                .and_then(|v| v.as_str())
+                .map(|s| s == "ISOLATED_MARGIN")
+                .unwrap_or(false);
+            if !is_isolated {
+                continue;
+            }
+            // Skip closed positions — the exchange can echo zero-quantity rows.
+            let qty = pos
+                .get("quantity")
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<f64>().ok())
+                .unwrap_or(0.0);
+            if qty == 0.0 {
+                continue;
+            }
+            let (Some(instrument), Some(isolation_id)) = (
+                pos.get("instrument_name").and_then(|v| v.as_str()),
+                pos.get("isolation_id").and_then(|v| v.as_str()),
+            ) else {
+                continue;
+            };
+            isolated.insert(instrument.to_string(), isolation_id.to_string());
+        }
+        self.isolated_positions = isolated;
+    }
+
     pub fn toast(&mut self, message: impl Into<String>, style: ToastStyle) {
         self.toast = Some(Toast {
             message: message.into(),

--- a/crates/cdcx-tui/src/streaming.rs
+++ b/crates/cdcx-tui/src/streaming.rs
@@ -12,6 +12,12 @@ pub enum StreamEvent {
     },
     BookUpdate(serde_json::Value),
     TradeUpdate(serde_json::Value),
+    /// `user.positions` channel — array of position records.
+    PositionsUpdate(Vec<serde_json::Value>),
+    /// `user.balance` channel — array of currency balance records.
+    BalanceUpdate(Vec<serde_json::Value>),
+    /// `user.order` channel — array of order records.
+    OrdersUpdate(Vec<serde_json::Value>),
     ConnectionStatus(ConnectionStatusEvent),
 }
 
@@ -20,6 +26,9 @@ pub enum ConnectionStatusEvent {
     MarketConnected,
     MarketReconnecting,
     MarketError(String),
+    UserConnected,
+    UserReconnecting,
+    UserError(String),
 }
 
 #[derive(Debug)]
@@ -189,5 +198,124 @@ impl StreamManager {
 
     pub fn shutdown(&self) {
         let _ = self.command_tx.send(StreamCommand::Shutdown);
+    }
+}
+
+/// Authenticated user-stream manager. Connects to ws_user_url, authenticates with the
+/// provided credentials, subscribes to the given user.* channels, and pushes updates
+/// into the same `StreamEvent` bus the market stream uses. Reconnects with backoff and
+/// re-authenticates+resubscribes on drop.
+pub struct UserStreamManager {
+    shutdown_tx: mpsc::UnboundedSender<()>,
+}
+
+impl UserStreamManager {
+    pub fn spawn(
+        env: Environment,
+        credentials: cdcx_core::auth::Credentials,
+        channels: Vec<String>,
+        event_tx: mpsc::UnboundedSender<StreamEvent>,
+    ) -> Self {
+        let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel::<()>();
+
+        tokio::spawn(async move {
+            let mut client: Option<cdcx_core::ws_client::WsClient> = None;
+            let mut retry_count = 0u32;
+
+            loop {
+                if client.is_none() {
+                    let _ = event_tx.send(StreamEvent::ConnectionStatus(
+                        ConnectionStatusEvent::UserReconnecting,
+                    ));
+                    match cdcx_core::ws_client::WsClient::authenticated_connect(
+                        &env.ws_user_url(),
+                        &credentials,
+                    )
+                    .await
+                    {
+                        Ok(mut ws) => {
+                            if let Err(e) = ws.subscribe(channels.clone()).await {
+                                let _ = event_tx.send(StreamEvent::ConnectionStatus(
+                                    ConnectionStatusEvent::UserError(e.to_string()),
+                                ));
+                                retry_count += 1;
+                                let delay =
+                                    std::cmp::min(500 * 2u64.pow(retry_count.min(10)), 30_000);
+                                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                                continue;
+                            }
+                            client = Some(ws);
+                            retry_count = 0;
+                            let _ = event_tx.send(StreamEvent::ConnectionStatus(
+                                ConnectionStatusEvent::UserConnected,
+                            ));
+                        }
+                        Err(e) => {
+                            let _ = event_tx.send(StreamEvent::ConnectionStatus(
+                                ConnectionStatusEvent::UserError(e.to_string()),
+                            ));
+                            retry_count += 1;
+                            let delay = std::cmp::min(500 * 2u64.pow(retry_count.min(10)), 30_000);
+                            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                            continue;
+                        }
+                    }
+                }
+
+                let ws = client.as_mut().unwrap();
+
+                tokio::select! {
+                    msg = ws.next_message() => {
+                        match msg {
+                            Some(Ok(value)) => {
+                                Self::route(&value, &event_tx);
+                            }
+                            Some(Err(_)) | None => {
+                                client = None;
+                                continue;
+                            }
+                        }
+                    }
+                    _ = shutdown_rx.recv() => break,
+                }
+            }
+        });
+
+        Self { shutdown_tx }
+    }
+
+    fn route(value: &serde_json::Value, event_tx: &mpsc::UnboundedSender<StreamEvent>) {
+        let Some(result) = value.get("result") else {
+            return;
+        };
+        let channel = result.get("channel").and_then(|c| c.as_str()).unwrap_or("");
+        let subscription = result
+            .get("subscription")
+            .and_then(|s| s.as_str())
+            .unwrap_or("");
+        let is_positions = channel == "user.positions" || subscription == "user.positions";
+        let is_balance = channel == "user.balance" || subscription == "user.balance";
+        let is_orders = channel == "user.order" || subscription == "user.order";
+        if !(is_positions || is_balance || is_orders) {
+            return;
+        }
+        let Some(data) = result.get("data") else {
+            return;
+        };
+        let arr: Vec<serde_json::Value> = data
+            .as_array()
+            .cloned()
+            .unwrap_or_else(|| vec![data.clone()]);
+        if is_positions {
+            let _ = event_tx.send(StreamEvent::PositionsUpdate(arr));
+        } else if is_balance {
+            let _ = event_tx.send(StreamEvent::BalanceUpdate(arr));
+        } else if is_orders {
+            let _ = event_tx.send(StreamEvent::OrdersUpdate(arr));
+        }
+    }
+
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(());
     }
 }

--- a/crates/cdcx-tui/src/tabs/mod.rs
+++ b/crates/cdcx-tui/src/tabs/mod.rs
@@ -58,6 +58,12 @@ pub enum DataEvent {
         method: String,
         data: serde_json::Value,
     },
+    /// Positions snapshot from `user.positions` WS channel.
+    PositionsSnapshot(Vec<serde_json::Value>),
+    /// Balance snapshot from `user.balance` WS channel.
+    BalanceSnapshot(Vec<serde_json::Value>),
+    /// Order update from `user.order` WS channel.
+    OrdersUpdate(Vec<serde_json::Value>),
 }
 
 pub trait Tab {

--- a/crates/cdcx-tui/src/tabs/orders.rs
+++ b/crates/cdcx-tui/src/tabs/orders.rs
@@ -306,4 +306,10 @@ impl Tab for OrdersTab {
     fn on_activate(&mut self) {
         self.loaded = false;
     }
+
+    fn selected_instrument(&self) -> Option<&str> {
+        self.orders
+            .get(self.selected)
+            .map(|o| o.instrument.as_str())
+    }
 }

--- a/crates/cdcx-tui/src/tabs/positions.rs
+++ b/crates/cdcx-tui/src/tabs/positions.rs
@@ -138,23 +138,56 @@ impl Tab for PositionsTab {
                                 .to_string();
                             let mark = state.tickers.get(&instrument).map(|t| t.ask).unwrap_or(0.0);
 
+                            // The exchange encodes direction in the sign of `quantity`
+                            // (positive = long, negative = short) and does NOT send an
+                            // explicit `side` field on positions. Fall back to the
+                            // quantity-sign convention when `side` is absent.
+                            let raw_qty: f64 = item
+                                .get("quantity")
+                                .and_then(|v| v.as_str())
+                                .and_then(|s| s.parse().ok())
+                                .unwrap_or(0.0);
+                            let side = item
+                                .get("side")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string())
+                                .unwrap_or_else(|| {
+                                    if raw_qty >= 0.0 {
+                                        "LONG".into()
+                                    } else {
+                                        "SHORT".into()
+                                    }
+                                });
+
+                            // The exchange returns `open_pos_cost` (total USD notional)
+                            // rather than a per-unit `average_price`. Divide to recover
+                            // the entry price. Fall back to `average_price` in case a
+                            // future API version adds it directly.
+                            let entry_price = item
+                                .get("average_price")
+                                .and_then(|v| v.as_str())
+                                .and_then(|s| s.parse::<f64>().ok())
+                                .filter(|p| *p > 0.0)
+                                .or_else(|| {
+                                    item.get("open_pos_cost")
+                                        .or_else(|| item.get("cost"))
+                                        .and_then(|v| v.as_str())
+                                        .and_then(|s| s.parse::<f64>().ok())
+                                        .and_then(|cost| {
+                                            if raw_qty.abs() > 0.0 {
+                                                Some(cost.abs() / raw_qty.abs())
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                })
+                                .unwrap_or(0.0);
+
                             Position {
                                 instrument,
-                                side: item
-                                    .get("side")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string(),
-                                quantity: item
-                                    .get("quantity")
-                                    .and_then(|v| v.as_str())
-                                    .and_then(|s| s.parse().ok())
-                                    .unwrap_or(0.0),
-                                entry_price: item
-                                    .get("average_price")
-                                    .and_then(|v| v.as_str())
-                                    .and_then(|s| s.parse().ok())
-                                    .unwrap_or(0.0),
+                                side,
+                                quantity: raw_qty.abs(),
+                                entry_price,
                                 mark_price: mark,
                                 pnl: item
                                     .get("session_pnl")
@@ -335,7 +368,7 @@ impl Tab for PositionsTab {
 
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(
-                "r:refresh  \u{2191}\u{2193}:navigate  Enter:detail",
+                "r:refresh  \u{2191}\u{2193}:navigate  Enter:detail  t:trade  x:close  o/O:OCO/OTOCO  c:cancel-orders",
                 Style::default().fg(state.theme.colors.muted),
             ))),
             footer_area,
@@ -352,6 +385,12 @@ impl Tab for PositionsTab {
 
     fn on_activate(&mut self) {
         self.loaded = false;
+    }
+
+    fn selected_instrument(&self) -> Option<&str> {
+        self.positions
+            .get(self.selected)
+            .map(|p| p.instrument.as_str())
     }
 }
 

--- a/crates/cdcx-tui/src/tabs/watchlist.rs
+++ b/crates/cdcx-tui/src/tabs/watchlist.rs
@@ -189,7 +189,7 @@ impl Tab for WatchlistTab {
 
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(
-                "a:add  d:remove  \u{2191}\u{2193}:navigate  Enter:details",
+                "a:add  d:remove  \u{2191}\u{2193}:navigate  Enter:details  t:trade  o/O:OCO/OTOCO  c:cancel",
                 Style::default().fg(state.theme.colors.muted),
             ))),
             footer_area,

--- a/crates/cdcx-tui/src/workflows/close_position.rs
+++ b/crates/cdcx-tui/src/workflows/close_position.rs
@@ -1,0 +1,522 @@
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+use crate::state::{AppState, RestRequest};
+use crate::workflows::{modal_area, Workflow, WorkflowResult};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Step {
+    /// Choose MARKET (immediate, slippage risk) or LIMIT (asks for price).
+    OrderType,
+    /// Only reached when OrderType = LIMIT.
+    Price,
+    Confirm,
+    Submitting,
+    Rejected,
+}
+
+pub struct ClosePositionWorkflow {
+    instrument: String,
+    /// Original position side — either "BUY"/"LONG" or "SELL"/"SHORT". The close order
+    /// takes the opposite side.
+    position_side: String,
+    /// Raw quantity string as returned by the exchange — preserves the exact precision
+    /// accepted for this instrument, avoiding qty_tick_size rounding errors that would
+    /// leave dust if we reformatted from f64.
+    quantity_str: String,
+    entry_price: f64,
+    mark_price: f64,
+    is_isolated: bool,
+    isolation_id: Option<String>,
+    step: Step,
+    order_type: usize, // 0 = MARKET, 1 = LIMIT
+    price_input: String,
+    error: Option<String>,
+    rejection: Option<(i64, String)>,
+}
+
+impl ClosePositionWorkflow {
+    /// Build the workflow from the positions snapshot. Returns None if the instrument
+    /// has no open position, or if the position has zero quantity (closed).
+    pub fn new(instrument: String, state: &AppState) -> Option<Self> {
+        let pos = state.positions_snapshot.iter().find(|p| {
+            p.get("instrument_name").and_then(|v| v.as_str()) == Some(instrument.as_str())
+        })?;
+        let quantity_str = pos.get("quantity").and_then(|v| v.as_str())?.to_string();
+        let quantity: f64 = quantity_str.parse().ok()?;
+        if quantity.abs() < 1e-12 {
+            return None;
+        }
+        let position_side = pos
+            .get("side")
+            .and_then(|v| v.as_str())
+            .unwrap_or(if quantity > 0.0 { "BUY" } else { "SELL" })
+            .to_string();
+        // API returns `open_pos_cost` (total USD) rather than per-unit price. Divide
+        // by |quantity| to recover entry price; prefer `average_price` if present.
+        let entry_price = pos
+            .get("average_price")
+            .or_else(|| pos.get("avg_entry_price"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<f64>().ok())
+            .filter(|p| *p > 0.0)
+            .or_else(|| {
+                pos.get("open_pos_cost")
+                    .or_else(|| pos.get("cost"))
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .and_then(|cost| {
+                        let abs_qty = quantity.abs();
+                        if abs_qty > 0.0 {
+                            Some(cost.abs() / abs_qty)
+                        } else {
+                            None
+                        }
+                    })
+            })
+            .unwrap_or(0.0);
+        let mark_price = state
+            .tickers
+            .get(&instrument)
+            .map(|t| t.ask)
+            .unwrap_or(entry_price);
+        let is_isolated = pos
+            .get("isolation_type")
+            .and_then(|v| v.as_str())
+            .map(|s| s == "ISOLATED_MARGIN")
+            .unwrap_or(false);
+        let isolation_id = state.isolated_positions.get(&instrument).cloned();
+
+        let _ = quantity; // parsed only as validity check — use quantity_str for submit
+        Some(Self {
+            instrument,
+            position_side,
+            quantity_str,
+            entry_price,
+            mark_price,
+            is_isolated,
+            isolation_id,
+            step: Step::OrderType,
+            order_type: 0,
+            price_input: String::new(),
+            error: None,
+            rejection: None,
+        })
+    }
+
+    /// The side for the close order — opposite of the position's side.
+    fn close_side(&self) -> &'static str {
+        match self.position_side.as_str() {
+            "BUY" | "LONG" => "SELL",
+            _ => "BUY",
+        }
+    }
+
+    fn type_str(&self) -> &'static str {
+        if self.order_type == 0 {
+            "MARKET"
+        } else {
+            "LIMIT"
+        }
+    }
+
+    fn submit(&self, state: &AppState) {
+        // Strip any leading sign from the quantity — some venue responses include it,
+        // but create-order always wants a positive quantity plus an explicit side.
+        let qty = self
+            .quantity_str
+            .trim_start_matches('-')
+            .trim_start_matches('+')
+            .to_string();
+        let mut params = serde_json::json!({
+            "instrument_name": self.instrument,
+            "side": self.close_side(),
+            "type": self.type_str(),
+            "quantity": qty,
+        });
+        if self.order_type == 1 {
+            params["price"] = serde_json::Value::String(self.price_input.clone());
+        }
+        if self.is_isolated {
+            params["exec_inst"] = serde_json::json!(["ISOLATED_MARGIN"]);
+            // For isolated positions, isolation_id is mandatory — otherwise we get 617.
+            // REDUCE_ONLY on an isolated position tells the exchange this must reduce
+            // the existing bucket rather than open a new one.
+            if let Some(ref id) = self.isolation_id {
+                params["isolation_id"] = serde_json::Value::String(id.clone());
+            }
+            if let Some(arr) = params["exec_inst"].as_array_mut() {
+                arr.push(serde_json::Value::String("REDUCE_ONLY".into()));
+            }
+        } else {
+            // Cross-margin close: REDUCE_ONLY still protects against accidentally
+            // flipping from long to short if quantity math ever goes wrong.
+            params["exec_inst"] = serde_json::json!(["REDUCE_ONLY"]);
+        }
+        // Stamp cx3- TUI origin prefix on client_oid for downstream attribution.
+        let _ = cdcx_core::origin::tag_params_in_place(
+            &mut params,
+            cdcx_core::origin::OriginChannel::Tui,
+        );
+        let _ = state.rest_tx.send(RestRequest {
+            method: "private/create-order".into(),
+            params,
+            is_private: true,
+        });
+    }
+}
+
+impl Workflow for ClosePositionWorkflow {
+    fn on_key(&mut self, key: KeyEvent, state: &mut AppState) -> WorkflowResult {
+        if key.code == KeyCode::Esc {
+            return WorkflowResult::Cancel;
+        }
+
+        match self.step {
+            Step::OrderType => match key.code {
+                KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') => {
+                    self.order_type = 1 - self.order_type;
+                }
+                KeyCode::Enter | KeyCode::Tab => {
+                    self.step = if self.order_type == 0 {
+                        Step::Confirm
+                    } else {
+                        // Pre-fill LIMIT price with mark so the user sees a sensible
+                        // anchor; they can edit/clear it with Backspace.
+                        if self.price_input.is_empty() && self.mark_price > 0.0 {
+                            self.price_input = format!("{:.2}", self.mark_price);
+                        }
+                        Step::Price
+                    };
+                }
+                _ => {}
+            },
+            Step::Price => match key.code {
+                KeyCode::Char(c) if c.is_ascii_digit() || c == '.' => {
+                    self.price_input.push(c);
+                    self.error = None;
+                }
+                KeyCode::Backspace => {
+                    self.price_input.pop();
+                }
+                KeyCode::Enter | KeyCode::Tab => {
+                    if self.price_input.is_empty() {
+                        self.error = Some("Price is required for LIMIT close".into());
+                    } else if self.price_input.parse::<f64>().is_err()
+                        || self.price_input.parse::<f64>().unwrap() <= 0.0
+                    {
+                        self.error = Some("Invalid price — enter a positive number".into());
+                    } else {
+                        self.error = None;
+                        self.step = Step::Confirm;
+                    }
+                }
+                KeyCode::BackTab => {
+                    self.step = Step::OrderType;
+                }
+                _ => {}
+            },
+            Step::Confirm => match key.code {
+                KeyCode::Enter | KeyCode::Char('y') => {
+                    self.step = Step::Submitting;
+                    self.submit(state);
+                }
+                KeyCode::BackTab => {
+                    self.step = if self.order_type == 0 {
+                        Step::OrderType
+                    } else {
+                        Step::Price
+                    };
+                }
+                _ => {}
+            },
+            Step::Submitting => {
+                // on_response() transitions to Rejected or returns Done.
+            }
+            Step::Rejected => match key.code {
+                KeyCode::Char('r' | 'R') | KeyCode::Enter => {
+                    self.rejection = None;
+                    self.step = Step::Submitting;
+                    self.submit(state);
+                }
+                KeyCode::Char('e' | 'E') => {
+                    self.rejection = None;
+                    self.step = Step::Confirm;
+                }
+                _ => {}
+            },
+        }
+        WorkflowResult::Continue
+    }
+
+    fn on_response(
+        &mut self,
+        method: &str,
+        data: &serde_json::Value,
+        state: &mut AppState,
+    ) -> WorkflowResult {
+        if method != "private/create-order" || self.step != Step::Submitting {
+            return WorkflowResult::Continue;
+        }
+        let code = data
+            .get("data")
+            .and_then(|d| d.get("code"))
+            .and_then(|v| v.as_i64())
+            .or_else(|| data.get("code").and_then(|v| v.as_i64()))
+            .unwrap_or(0);
+        if code == 0 {
+            state.toast(
+                format!("Close order submitted — {}", self.instrument),
+                crate::state::ToastStyle::Success,
+            );
+            return WorkflowResult::Done;
+        }
+        let message = data
+            .get("data")
+            .and_then(|d| d.get("message"))
+            .or_else(|| data.get("message"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("Close rejected")
+            .to_string();
+        if code == 617 && self.isolation_id.is_none() {
+            // Cache missed — refresh positions so the retry can auto-attach the ID.
+            let _ = state.rest_tx.send(RestRequest {
+                method: "private/get-positions".into(),
+                params: serde_json::json!({}),
+                is_private: true,
+            });
+        }
+        self.rejection = Some((code, message));
+        self.step = Step::Rejected;
+        WorkflowResult::Continue
+    }
+
+    fn draw(&self, frame: &mut Frame, area: Rect, state: &AppState) {
+        let modal = modal_area(area, 60, 16);
+        frame.render_widget(Clear, modal);
+
+        let title = if self.is_isolated {
+            " Close Position (Isolated) "
+        } else {
+            " Close Position "
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(state.theme.colors.negative))
+            .title(title);
+        let inner = block.inner(modal);
+        frame.render_widget(block, modal);
+
+        let lines = Layout::vertical([
+            Constraint::Length(1), // spacing
+            Constraint::Length(1), // position summary 1
+            Constraint::Length(1), // position summary 2
+            Constraint::Length(1), // spacing
+            Constraint::Length(1), // order type
+            Constraint::Length(1), // price (LIMIT only — blank otherwise)
+            Constraint::Length(1), // separator
+            Constraint::Length(2), // confirm / status
+            Constraint::Length(2), // error / rejection
+            Constraint::Length(1), // help
+        ])
+        .areas::<10>(inner);
+
+        let muted = Style::default().fg(state.theme.colors.muted);
+        let active = Style::default()
+            .fg(state.theme.colors.accent)
+            .add_modifier(Modifier::BOLD);
+
+        let side_color = if matches!(self.position_side.as_str(), "BUY" | "LONG") {
+            state.theme.colors.positive
+        } else {
+            state.theme.colors.negative
+        };
+
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Position: ", muted),
+                Span::styled(
+                    self.position_side.as_str(),
+                    Style::default().fg(side_color).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" "),
+                Span::styled(self.quantity_str.as_str(), active),
+                Span::raw(" "),
+                Span::styled(
+                    self.instrument.as_str(),
+                    Style::default()
+                        .fg(state.theme.colors.accent)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ])),
+            lines[1],
+        );
+
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Entry: ", muted),
+                Span::raw(format!("{:.2}", self.entry_price)),
+                Span::raw("   "),
+                Span::styled("Mark: ", muted),
+                Span::raw(format!("{:.2}", self.mark_price)),
+                Span::raw("   "),
+                Span::styled(
+                    if self.is_isolated {
+                        "[ISOLATED]"
+                    } else {
+                        "[CROSS]"
+                    },
+                    muted,
+                ),
+            ])),
+            lines[2],
+        );
+
+        // Order type row
+        let type_label_style = if self.step == Step::OrderType {
+            active
+        } else {
+            muted
+        };
+        let market_style = if self.order_type == 0 { active } else { muted };
+        let limit_style = if self.order_type == 1 { active } else { muted };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Close via: ", type_label_style),
+                Span::styled(
+                    if self.order_type == 0 {
+                        "[MARKET]"
+                    } else {
+                        " MARKET "
+                    },
+                    market_style,
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    if self.order_type == 1 {
+                        "[LIMIT]"
+                    } else {
+                        " LIMIT "
+                    },
+                    limit_style,
+                ),
+            ])),
+            lines[4],
+        );
+
+        // Price row (only when LIMIT chosen)
+        if self.order_type == 1 {
+            let price_style = if self.step == Step::Price {
+                active
+            } else {
+                muted
+            };
+            let price_display = if self.price_input.is_empty() && self.step == Step::Price {
+                "\u{2588}".to_string()
+            } else if self.step == Step::Price {
+                format!("{}\u{2588}", self.price_input)
+            } else {
+                self.price_input.clone()
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("Price:     ", price_style),
+                    Span::styled(
+                        price_display,
+                        if self.step == Step::Price {
+                            active
+                        } else {
+                            muted
+                        },
+                    ),
+                ])),
+                lines[5],
+            );
+        }
+
+        frame.render_widget(
+            Paragraph::new("\u{2500}".repeat(inner.width as usize))
+                .style(Style::default().fg(state.theme.colors.border)),
+            lines[6],
+        );
+
+        match self.step {
+            Step::Confirm => {
+                let price_segment = if self.order_type == 0 {
+                    "@ MARKET".to_string()
+                } else {
+                    format!("@ {}", self.price_input)
+                };
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![Span::styled(
+                        format!(
+                            "Close: {} {} {} {}",
+                            self.close_side(),
+                            self.quantity_str,
+                            self.instrument,
+                            price_segment,
+                        ),
+                        Style::default()
+                            .fg(state.theme.colors.negative)
+                            .add_modifier(Modifier::BOLD),
+                    )])),
+                    lines[7],
+                );
+            }
+            Step::Submitting => {
+                frame.render_widget(
+                    Paragraph::new("Submitting close order...")
+                        .style(Style::default().fg(state.theme.colors.accent)),
+                    lines[7],
+                );
+            }
+            Step::Rejected => {
+                frame.render_widget(
+                    Paragraph::new("Close rejected by exchange")
+                        .style(Style::default().fg(state.theme.colors.negative)),
+                    lines[7],
+                );
+            }
+            _ => {}
+        }
+
+        if let Some((code, ref message)) = self.rejection {
+            let has_isolation_id = self.isolation_id.is_some()
+                || state.isolated_positions.contains_key(&self.instrument);
+            let hint = match code {
+                617 if has_isolation_id => "  (R to retry with isolation_id)".to_string(),
+                617 => "  (waiting on positions refresh; try R again shortly)".to_string(),
+                _ => String::new(),
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(
+                        format!("[{}] {}", code, message),
+                        Style::default().fg(state.theme.colors.negative),
+                    ),
+                    Span::styled(hint, muted),
+                ])),
+                lines[8],
+            );
+        } else if let Some(ref err) = self.error {
+            frame.render_widget(
+                Paragraph::new(err.as_str())
+                    .style(Style::default().fg(state.theme.colors.negative)),
+                lines[8],
+            );
+        }
+
+        let help = match self.step {
+            Step::OrderType => "\u{2190}\u{2192}/Space:toggle  Enter:next  Esc:cancel",
+            Step::Price => "type price  Enter:next  Shift+Tab:back  Esc:cancel",
+            Step::Confirm => "Enter/y:close position  Shift+Tab:back  Esc:cancel",
+            Step::Submitting => "waiting...",
+            Step::Rejected => "R/Enter:retry  E:edit  Esc:cancel",
+        };
+        frame.render_widget(Paragraph::new(help).style(muted), lines[9]);
+    }
+}

--- a/crates/cdcx-tui/src/workflows/mod.rs
+++ b/crates/cdcx-tui/src/workflows/mod.rs
@@ -1,4 +1,5 @@
 pub mod cancel_order;
+pub mod close_position;
 pub mod oco_order;
 pub mod otoco_order;
 pub mod paper_order;
@@ -20,6 +21,18 @@ pub enum WorkflowResult {
 pub trait Workflow {
     fn on_key(&mut self, key: KeyEvent, state: &mut AppState) -> WorkflowResult;
     fn draw(&self, frame: &mut Frame, area: Rect, state: &AppState);
+    /// Called when the REST response for this workflow's submitted request arrives.
+    /// Return `Continue` to keep the modal open (e.g. business-logic rejection — show the
+    /// error so the user can retry), `Done` to close it on success, or `Cancel` to abort.
+    /// Default keeps modal open — concrete workflows override to opt into auto-close.
+    fn on_response(
+        &mut self,
+        _method: &str,
+        _data: &serde_json::Value,
+        _state: &mut AppState,
+    ) -> WorkflowResult {
+        WorkflowResult::Continue
+    }
 }
 
 /// Draw a centered modal box with a border and title.

--- a/crates/cdcx-tui/src/workflows/oco_order.rs
+++ b/crates/cdcx-tui/src/workflows/oco_order.rs
@@ -44,7 +44,7 @@ impl OcoOrderWorkflow {
     }
 
     fn submit(&self, state: &AppState) {
-        let params = serde_json::json!({
+        let mut params = serde_json::json!({
             "contingency_type": "OCO",
             "order_list": [
                 {
@@ -63,6 +63,8 @@ impl OcoOrderWorkflow {
                 }
             ]
         });
+        // Stamp cx3- TUI origin prefix on each leg's client_oid.
+        cdcx_core::origin::tag_order_list_legs(&mut params, cdcx_core::origin::OriginChannel::Tui);
         let _ = state.rest_tx.send(RestRequest {
             method: "private/create-order-list".into(),
             params,

--- a/crates/cdcx-tui/src/workflows/otoco_order.rs
+++ b/crates/cdcx-tui/src/workflows/otoco_order.rs
@@ -65,7 +65,7 @@ impl OtocoOrderWorkflow {
     }
 
     fn submit(&self, state: &AppState) {
-        let params = serde_json::json!({
+        let mut params = serde_json::json!({
             "contingency_type": "OTOCO",
             "order_list": [
                 {
@@ -91,6 +91,8 @@ impl OtocoOrderWorkflow {
                 }
             ]
         });
+        // Stamp cx3- TUI origin prefix on each leg's client_oid.
+        cdcx_core::origin::tag_order_list_legs(&mut params, cdcx_core::origin::OriginChannel::Tui);
         let _ = state.rest_tx.send(RestRequest {
             method: "private/create-order-list".into(),
             params,

--- a/crates/cdcx-tui/src/workflows/place_order.rs
+++ b/crates/cdcx-tui/src/workflows/place_order.rs
@@ -13,10 +13,12 @@ enum Step {
     Instrument,
     Side,
     OrderType,
+    Margin,
     Price,
     Quantity,
     Confirm,
     Submitting,
+    Rejected,
 }
 
 pub struct PlaceOrderWorkflow {
@@ -28,11 +30,27 @@ pub struct PlaceOrderWorkflow {
     price_input: String,
     qty_input: String,
     error: Option<String>,
+    isolated_margin: bool,
+    /// Exchange error message + code from the most recent rejection, if any.
+    /// When set, the modal sits on `Step::Rejected` and offers retry paths.
+    rejection: Option<(i64, String)>,
+}
+
+/// inst_types that default to requiring isolated margin on this exchange.
+/// Single-stock perpetuals (e.g. SPYUSD-PERP, NVDAUSD-PERP) are the known case.
+/// Crypto perpetuals are NOT in this list — they work on cross margin by default.
+fn requires_isolated_margin(inst_type: &str) -> bool {
+    matches!(inst_type, "EQUITY_PERP" | "EQUITY_PERPETUAL")
 }
 
 impl PlaceOrderWorkflow {
-    pub fn new(instrument: String) -> Self {
+    pub fn new(instrument: String, state: &AppState) -> Self {
         let instrument_input = instrument.clone();
+        let isolated_default = state
+            .instrument_types
+            .get(&instrument)
+            .map(|t| requires_isolated_margin(t))
+            .unwrap_or(false);
         Self {
             instrument,
             instrument_input,
@@ -42,6 +60,8 @@ impl PlaceOrderWorkflow {
             price_input: String::new(),
             qty_input: String::new(),
             error: None,
+            isolated_margin: isolated_default,
+            rejection: None,
         }
     }
 
@@ -71,6 +91,22 @@ impl PlaceOrderWorkflow {
         if self.order_type == 0 {
             params["price"] = serde_json::Value::String(self.price_input.clone());
         }
+        if self.isolated_margin {
+            params["exec_inst"] = serde_json::json!(["ISOLATED_MARGIN"]);
+            // Attach isolation_id if we already have an open isolated position on this
+            // instrument. The exchange rejects a second bare-isolated order on the same
+            // instrument with error 617 (DUPLICATED_INSTRUMENT_ORDER_FOR_ISOLATED_MARGIN);
+            // referencing the existing bucket topping-up / trimming it instead.
+            if let Some(id) = state.isolated_positions.get(&self.instrument) {
+                params["isolation_id"] = serde_json::Value::String(id.clone());
+            }
+        }
+        // Stamp cx3- TUI origin prefix on client_oid so orders placed from the dashboard
+        // are attributable downstream. See cdcx-core::origin for the scheme.
+        let _ = cdcx_core::origin::tag_params_in_place(
+            &mut params,
+            cdcx_core::origin::OriginChannel::Tui,
+        );
         let _ = state.rest_tx.send(RestRequest {
             method: "private/create-order".into(),
             params,
@@ -83,6 +119,19 @@ impl Workflow for PlaceOrderWorkflow {
     fn on_key(&mut self, key: KeyEvent, state: &mut AppState) -> WorkflowResult {
         if key.code == KeyCode::Esc {
             return WorkflowResult::Cancel;
+        }
+
+        // Global: M toggles isolated margin from any editable step.
+        // Not available while typing free-text (Instrument/Price/Quantity) to avoid
+        // swallowing the user's keystroke. From Side/OrderType/Margin/Confirm it's safe.
+        if let KeyCode::Char('m' | 'M') = key.code {
+            if matches!(
+                self.step,
+                Step::Side | Step::OrderType | Step::Margin | Step::Confirm
+            ) {
+                self.isolated_margin = !self.isolated_margin;
+                return WorkflowResult::Continue;
+            }
         }
 
         match self.step {
@@ -102,6 +151,12 @@ impl Workflow for PlaceOrderWorkflow {
                         self.error = Some(format!("Unknown instrument: {}", trimmed));
                     } else {
                         self.instrument = trimmed;
+                        // Re-evaluate isolated-margin default for the picked instrument.
+                        if let Some(t) = state.instrument_types.get(&self.instrument) {
+                            if requires_isolated_margin(t) {
+                                self.isolated_margin = true;
+                            }
+                        }
                         self.error = None;
                         self.step = Step::Side;
                     }
@@ -125,6 +180,18 @@ impl Workflow for PlaceOrderWorkflow {
                     self.order_type = 1 - self.order_type;
                 }
                 KeyCode::Enter | KeyCode::Tab => {
+                    self.step = Step::Margin;
+                }
+                KeyCode::BackTab => {
+                    self.step = Step::Side;
+                }
+                _ => {}
+            },
+            Step::Margin => match key.code {
+                KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') => {
+                    self.isolated_margin = !self.isolated_margin;
+                }
+                KeyCode::Enter | KeyCode::Tab => {
                     self.step = if self.order_type == 0 {
                         Step::Price
                     } else {
@@ -132,7 +199,7 @@ impl Workflow for PlaceOrderWorkflow {
                     };
                 }
                 KeyCode::BackTab => {
-                    self.step = Step::Side;
+                    self.step = Step::OrderType;
                 }
                 _ => {}
             },
@@ -157,7 +224,7 @@ impl Workflow for PlaceOrderWorkflow {
                     }
                 }
                 KeyCode::BackTab => {
-                    self.step = Step::OrderType;
+                    self.step = Step::Margin;
                 }
                 _ => {}
             },
@@ -185,7 +252,7 @@ impl Workflow for PlaceOrderWorkflow {
                     self.step = if self.order_type == 0 {
                         Step::Price
                     } else {
-                        Step::OrderType
+                        Step::Margin
                     };
                 }
                 _ => {}
@@ -201,14 +268,78 @@ impl Workflow for PlaceOrderWorkflow {
                 _ => {}
             },
             Step::Submitting => {
-                // App.on_data() closes the workflow when response arrives
+                // on_response() will advance to Rejected or WorkflowResult::Done.
             }
+            Step::Rejected => match key.code {
+                KeyCode::Char('r' | 'R') | KeyCode::Enter => {
+                    // Retry with current settings (user may have pressed M to flip margin).
+                    self.rejection = None;
+                    self.step = Step::Submitting;
+                    self.submit(state);
+                }
+                KeyCode::Char('e' | 'E') => {
+                    // Back to edit — land on Confirm so user can Shift+Tab back through fields.
+                    self.rejection = None;
+                    self.step = Step::Confirm;
+                }
+                _ => {}
+            },
         }
         WorkflowResult::Continue
     }
 
+    fn on_response(
+        &mut self,
+        method: &str,
+        data: &serde_json::Value,
+        state: &mut AppState,
+    ) -> WorkflowResult {
+        if method != "private/create-order" || self.step != Step::Submitting {
+            return WorkflowResult::Continue;
+        }
+        // The API client returns Ok(...) with embedded code+message for business-logic
+        // rejections (see cdcx-core/src/api_client.rs:183-193). Code 0 or missing = success.
+        let code = data
+            .get("data")
+            .and_then(|d| d.get("code"))
+            .and_then(|v| v.as_i64())
+            .or_else(|| data.get("code").and_then(|v| v.as_i64()))
+            .unwrap_or(0);
+        if code == 0 {
+            state.toast(
+                if self.isolated_margin {
+                    "Order placed (isolated margin)".to_string()
+                } else {
+                    "Order placed".to_string()
+                },
+                crate::state::ToastStyle::Success,
+            );
+            return WorkflowResult::Done;
+        }
+        let message = data
+            .get("data")
+            .and_then(|d| d.get("message"))
+            .or_else(|| data.get("message"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("Order rejected")
+            .to_string();
+        // Error 617 means an isolated position for this instrument already exists —
+        // we need the isolation_id to add to / trim it. Kick off a positions refresh
+        // so the retry path has it even if the WS snapshot hasn't landed yet.
+        if code == 617 && !state.isolated_positions.contains_key(&self.instrument) {
+            let _ = state.rest_tx.send(RestRequest {
+                method: "private/get-positions".into(),
+                params: serde_json::json!({}),
+                is_private: true,
+            });
+        }
+        self.rejection = Some((code, message));
+        self.step = Step::Rejected;
+        WorkflowResult::Continue
+    }
+
     fn draw(&self, frame: &mut Frame, area: Rect, state: &AppState) {
-        let modal = modal_area(area, 54, 18);
+        let modal = modal_area(area, 60, 20);
         frame.render_widget(Clear, modal);
 
         let block = Block::default()
@@ -223,12 +354,12 @@ impl Workflow for PlaceOrderWorkflow {
             Constraint::Length(1), // instrument
             Constraint::Length(1), // side
             Constraint::Length(1), // type
+            Constraint::Length(1), // margin
             Constraint::Length(1), // price
             Constraint::Length(1), // quantity
-            Constraint::Length(1), // spacing
             Constraint::Length(1), // separator
-            Constraint::Length(2), // summary / confirm
-            Constraint::Length(1), // error
+            Constraint::Length(2), // summary / confirm / rejected
+            Constraint::Length(2), // error / rejection-message
             Constraint::Length(1), // help
         ])
         .areas::<11>(inner);
@@ -258,7 +389,7 @@ impl Workflow for PlaceOrderWorkflow {
         };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("Inst:  ", inst_style),
+                Span::styled("Inst:   ", inst_style),
                 Span::styled(inst_display, inst_value_style),
             ])),
             lines[1],
@@ -286,7 +417,7 @@ impl Workflow for PlaceOrderWorkflow {
         };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("Side:  ", side_style),
+                Span::styled("Side:   ", side_style),
                 Span::styled(if self.side == 0 { "[BUY]" } else { " BUY " }, buy_style),
                 Span::raw("  "),
                 Span::styled(if self.side == 1 { "[SELL]" } else { " SELL " }, sell_style),
@@ -302,7 +433,7 @@ impl Workflow for PlaceOrderWorkflow {
         };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("Type:  ", type_style),
+                Span::styled("Type:   ", type_style),
                 Span::styled(
                     if self.order_type == 0 {
                         "[LIMIT]"
@@ -332,6 +463,47 @@ impl Workflow for PlaceOrderWorkflow {
             lines[3],
         );
 
+        // Margin
+        let margin_label_style = if self.step == Step::Margin {
+            active_style
+        } else {
+            dim_style
+        };
+        let iso_label = if self.isolated_margin {
+            "[ISOLATED]"
+        } else {
+            " ISOLATED "
+        };
+        let cross_label = if self.isolated_margin {
+            " CROSS "
+        } else {
+            "[CROSS]"
+        };
+        let iso_style = if self.isolated_margin {
+            Style::default()
+                .fg(state.theme.colors.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            dim_style
+        };
+        let cross_style = if !self.isolated_margin {
+            Style::default()
+                .fg(state.theme.colors.fg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            dim_style
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Margin: ", margin_label_style),
+                Span::styled(iso_label, iso_style),
+                Span::raw("  "),
+                Span::styled(cross_label, cross_style),
+                Span::styled("   (M to toggle)", dim_style),
+            ])),
+            lines[4],
+        );
+
         // Price
         let price_style = if self.step == Step::Price {
             active_style
@@ -349,7 +521,7 @@ impl Workflow for PlaceOrderWorkflow {
         };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("Price: ", price_style),
+                Span::styled("Price:  ", price_style),
                 Span::styled(
                     price_display,
                     if self.step == Step::Price {
@@ -359,7 +531,7 @@ impl Workflow for PlaceOrderWorkflow {
                     },
                 ),
             ])),
-            lines[4],
+            lines[5],
         );
 
         // Quantity
@@ -377,7 +549,7 @@ impl Workflow for PlaceOrderWorkflow {
         };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
-                Span::styled("Qty:   ", qty_style),
+                Span::styled("Qty:    ", qty_style),
                 Span::styled(
                     qty_display,
                     if self.step == Step::Quantity {
@@ -387,7 +559,7 @@ impl Workflow for PlaceOrderWorkflow {
                     },
                 ),
             ])),
-            lines[5],
+            lines[6],
         );
 
         // Separator
@@ -397,13 +569,18 @@ impl Workflow for PlaceOrderWorkflow {
             lines[7],
         );
 
-        // Confirm / status
+        // Confirm / status / rejected
         match self.step {
             Step::Confirm => {
+                let margin_tag = if self.isolated_margin {
+                    "  [ISOLATED]"
+                } else {
+                    ""
+                };
                 frame.render_widget(
                     Paragraph::new(Line::from(vec![Span::styled(
                         format!(
-                            "{} {} {} @ {}",
+                            "{} {} {} @ {}{}",
                             self.side_str(),
                             self.qty_input,
                             self.instrument,
@@ -411,7 +588,8 @@ impl Workflow for PlaceOrderWorkflow {
                                 &self.price_input
                             } else {
                                 "MARKET"
-                            }
+                            },
+                            margin_tag,
                         ),
                         Style::default()
                             .fg(state.theme.colors.accent)
@@ -427,11 +605,41 @@ impl Workflow for PlaceOrderWorkflow {
                     lines[8],
                 );
             }
+            Step::Rejected => {
+                frame.render_widget(
+                    Paragraph::new("Order rejected by exchange")
+                        .style(Style::default().fg(state.theme.colors.negative)),
+                    lines[8],
+                );
+            }
             _ => {}
         }
 
-        // Error
-        if let Some(ref err) = self.error {
+        // Error / rejection detail
+        if let Some((code, ref message)) = self.rejection {
+            let has_isolation_id = state.isolated_positions.contains_key(&self.instrument);
+            let hint = match code {
+                623 if !self.isolated_margin => {
+                    "  (press M then R to retry with isolated margin)".to_string()
+                }
+                617 if has_isolation_id => {
+                    "  (R to retry — will attach your open isolation_id)".to_string()
+                }
+                617 => "  (waiting on positions stream; check `cdcx account positions` then R)"
+                    .to_string(),
+                _ => String::new(),
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(
+                        format!("[{}] {}", code, message),
+                        Style::default().fg(state.theme.colors.negative),
+                    ),
+                    Span::styled(hint, Style::default().fg(state.theme.colors.muted)),
+                ])),
+                lines[9],
+            );
+        } else if let Some(ref err) = self.error {
             frame.render_widget(
                 Paragraph::new(err.as_str())
                     .style(Style::default().fg(state.theme.colors.negative)),
@@ -443,11 +651,13 @@ impl Workflow for PlaceOrderWorkflow {
         let help = match self.step {
             Step::Instrument => "type instrument  Tab:next  Esc:cancel",
             Step::Side | Step::OrderType => {
-                "\u{2190}\u{2192}:select  Tab:next  Shift+Tab:back  Esc:cancel"
+                "\u{2190}\u{2192}:select  Tab:next  Shift+Tab:back  M:margin  Esc:cancel"
             }
+            Step::Margin => "\u{2190}\u{2192}/Space:toggle  Tab:next  Shift+Tab:back  Esc:cancel",
             Step::Price | Step::Quantity => "type value  Tab:next  Shift+Tab:back  Esc:cancel",
-            Step::Confirm => "Enter:submit  Shift+Tab:back  Esc:cancel",
+            Step::Confirm => "Enter:submit  M:toggle margin  Shift+Tab:back  Esc:cancel",
             Step::Submitting => "waiting...",
+            Step::Rejected => "R/Enter:retry  M:toggle margin  E:edit  Esc:cancel",
         };
         frame.render_widget(
             Paragraph::new(help).style(Style::default().fg(state.theme.colors.muted)),

--- a/skills/cdcx-isolated-margin.md
+++ b/skills/cdcx-isolated-margin.md
@@ -1,0 +1,231 @@
+---
+name: cdcx-isolated-margin
+description: Trade instruments that require isolated margin (e.g. RWA/equity perpetuals like SPYUSD-PERP). Covers the create-order flag, funding transfers, leverage adjustment, and the TUI M toggle.
+---
+
+# Isolated Margin
+
+## When to Use
+
+Some instruments — notably equity/RWA perpetuals such as `SPYUSD-PERP` and `NVDAUSD-PERP` — cannot be traded on the default cross-margin account. Attempting to do so returns:
+
+```json
+{
+  "code": 623,
+  "message": "INSTRUMENT_MUST_USE_ISOLATED_MARGIN"
+}
+```
+
+Isolated margin puts the position in its own margin bucket with its own leverage. Losses are capped at the isolated balance; a wipeout on one position cannot cascade into cross-margin balances on other instruments.
+
+Use isolated margin when:
+- The exchange requires it (error `623`).
+- You want per-position risk isolation (e.g. high-leverage directional bet).
+- You want a distinct leverage setting on one instrument without changing your cross-account config.
+
+Do **not** use isolated margin for:
+- Spot pairs (`CCY_PAIR`) — not applicable.
+- Crypto perpetuals where you want shared collateral across positions.
+
+## One Position Per Instrument
+
+The exchange enforces **one isolated position per instrument per account**. You cannot open two separate isolated buckets on `SPYUSD-PERP` — the second order must reference the first position's `isolation_id` so the exchange knows whether you're adding to, trimming, or reversing it.
+
+To top up or trim an open isolated position:
+
+1. Look up its `isolation_id` via `cdcx account positions -o json` (or the `user.positions` WS channel).
+2. Include `--isolation-id <ID>` on the next `cdcx trade order` call.
+
+Omitting `--isolation-id` on a second order returns:
+
+```json
+{
+  "code": 617,
+  "message": "DUPLICATED_INSTRUMENT_ORDER_FOR_ISOLATED_MARGIN"
+}
+```
+
+## TUI Workflow
+
+Open the place-order modal (`t` on the Market tab) and use the **Margin** row:
+
+```
+Inst:   SPYUSD-PERP
+Side:   [BUY]   SELL
+Type:   [LIMIT] MARKET
+Margin: [ISOLATED]  CROSS    (M to toggle)
+Price:  710.25
+Qty:    0.001
+```
+
+- `←/→` or `Space` while on the Margin row, or **`M` from anywhere in the modal** (except free-text fields), flips `ISOLATED ↔ CROSS`.
+- Isolated margin is **pre-selected automatically** for instruments whose `inst_type` requires it (e.g. equity perpetuals).
+- On success, the toast reads `Order placed (isolated margin)` so the mode is unambiguous.
+- The TUI subscribes to `user.positions` at startup (when authenticated) so `isolation_id` for any open isolated position is cached and **auto-attached** to your next order on the same instrument. You do not need to supply it manually in the TUI.
+
+### Handling Rejection
+
+The modal **stays open** on any exchange rejection, showing the code and message so you can decide how to recover.
+
+**Error 623 — `INSTRUMENT_MUST_USE_ISOLATED_MARGIN`**
+
+```
+[623] INSTRUMENT_MUST_USE_ISOLATED_MARGIN  (press M then R to retry with isolated margin)
+
+R/Enter:retry  M:toggle margin  E:edit  Esc:cancel
+```
+
+Press `M` → `R` to resubmit the exact same payload with `exec_inst: ["ISOLATED_MARGIN"]`. No re-typing.
+
+**Error 617 — `DUPLICATED_INSTRUMENT_ORDER_FOR_ISOLATED_MARGIN`**
+
+You already have an isolated position on this instrument. If the TUI has cached the `isolation_id` (which it will have from the `user.positions` stream), the hint reads:
+
+```
+[617] DUPLICATED_INSTRUMENT_ORDER_FOR_ISOLATED_MARGIN  (R to retry — will attach your open isolation_id)
+```
+
+Press `R` and the retry includes the correct `isolation_id` automatically.
+
+If the cache is empty (e.g. WS hadn't pushed the position yet), the TUI triggers a REST `private/get-positions` refresh in the background and shows:
+
+```
+[617] DUPLICATED_INSTRUMENT_ORDER_FOR_ISOLATED_MARGIN  (waiting on positions stream; check `cdcx account positions` then R)
+```
+
+Give it a moment then press `R` — the cache will be populated by then.
+
+## Closing Positions (TUI)
+
+On the **Positions** tab, select a row and press `x` to open the close-position modal. Two choices:
+
+- **MARKET** — immediate fill at the best available price. Fast but exposes you to slippage, especially on thin books.
+- **LIMIT** — pre-filled with the current mark price; edit to your desired exit level. Safer on illiquid instruments, but may not fill if the market moves away.
+
+The workflow:
+
+- Automatically flips the side (LONG → SELL, SHORT → BUY).
+- Uses the **exact** quantity from the positions snapshot, preserving `qty_tick_size` precision — avoids leaving dust.
+- Attaches `REDUCE_ONLY` so the order cannot accidentally flip your position.
+- For isolated positions, attaches `exec_inst: [ISOLATED_MARGIN, REDUCE_ONLY]` and the correct `isolation_id` automatically.
+
+If the exchange rejects the close (e.g. error 617 before the WS has pushed the `isolation_id`), the modal stays open with a retry hint. Press `R` once the positions snapshot has refreshed.
+
+## CLI Workflow
+
+### Place an order on isolated margin
+
+```bash
+cdcx trade order BUY SPYUSD-PERP 0.001 \
+    --type LIMIT --price 710.25 \
+    --exec-inst ISOLATED_MARGIN \
+    -o json
+```
+
+`--exec-inst` is repeatable if you need to combine flags:
+
+```bash
+cdcx trade order BUY SPYUSD-PERP 0.001 \
+    --type LIMIT --price 710.25 \
+    --exec-inst ISOLATED_MARGIN \
+    --exec-inst POST_ONLY \
+    -o json
+```
+
+Optional tuning:
+
+```bash
+    --isolated-margin-amount 200   # USD to lock into the position's margin bucket
+    --isolation-id <ID>            # Target an existing isolated position
+    --leverage 5                   # Per-position max leverage
+```
+
+If you omit `--isolation-id`, the exchange creates a new isolated position. The response includes the `isolation_id` — store it if you plan to top up margin or change leverage later.
+
+### Fund an isolated position
+
+Move USD from your cross account into the isolated position's margin bucket:
+
+```bash
+cdcx margin transfer \
+    --direction IN \
+    --amount 100 \
+    <ISOLATION_ID>
+```
+
+Withdraw unused margin back out:
+
+```bash
+cdcx margin transfer \
+    --direction OUT \
+    --amount 50 \
+    <ISOLATION_ID>
+```
+
+Always dry-run first when moving funds:
+
+```bash
+cdcx margin transfer --direction IN --amount 100 <ISOLATION_ID> --dry-run
+```
+
+### Adjust leverage
+
+```bash
+cdcx margin leverage --leverage 5 <ISOLATION_ID>
+```
+
+Lower leverage reduces liquidation risk at the cost of more locked margin. Higher leverage is the inverse.
+
+## Complete Flow Example
+
+Open an isolated long on `SPYUSD-PERP` at 5x with $200 margin:
+
+```bash
+# 1. Preflight: confirm instrument is tradable
+cdcx market instruments -o json | \
+    jq '.data.data[] | select(.symbol=="SPYUSD-PERP")'
+
+# 2. Check current price
+cdcx market ticker SPYUSD-PERP -o json
+
+# 3. Dry-run the order
+cdcx trade order BUY SPYUSD-PERP 0.1 \
+    --type LIMIT --price 710.00 \
+    --exec-inst ISOLATED_MARGIN \
+    --isolated-margin-amount 200 \
+    --leverage 5 \
+    --client-oid spy-long-$(date +%s) \
+    --dry-run -o json
+
+# 4. Place for real; capture the isolation_id
+ORDER=$(cdcx trade order BUY SPYUSD-PERP 0.1 \
+    --type LIMIT --price 710.00 \
+    --exec-inst ISOLATED_MARGIN \
+    --isolated-margin-amount 200 \
+    --leverage 5 \
+    -o json)
+ISOLATION_ID=$(echo "$ORDER" | jq -r '.data.isolation_id')
+
+# 5. Later: top up another $100 if price moves against us
+cdcx margin transfer --direction IN --amount 100 "$ISOLATION_ID"
+
+# 6. Change leverage mid-position
+cdcx margin leverage --leverage 3 "$ISOLATION_ID"
+```
+
+## Common Errors
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `623` / `INSTRUMENT_MUST_USE_ISOLATED_MARGIN` | Instrument requires isolated margin | Add `--exec-inst ISOLATED_MARGIN` |
+| `617` / `DUPLICATED_INSTRUMENT_ORDER_FOR_ISOLATED_MARGIN` | You already have an isolated position on this instrument | Fetch its `isolation_id` from `cdcx account positions` and pass `--isolation-id <ID>` to add/trim it |
+| `INSUFFICIENT_BALANCE` | Not enough free USD to lock as margin | Reduce `--isolated-margin-amount` or top up the cross account |
+| `INVALID_LEVERAGE` | Leverage outside instrument's allowed range | Check instrument metadata for `max_leverage` |
+| `ISOLATION_NOT_FOUND` | `--isolation-id` doesn't match an open position | Omit it to create a new position, or list positions to find the right ID |
+
+## Notes
+
+- Isolated-margin positions appear under `cdcx account positions` alongside cross-margin positions, but have a distinct `isolation_id`.
+- Closing an isolated position does **not** auto-return the margin to your cross account — use `cdcx margin transfer --direction OUT` to reclaim it.
+- The TUI auto-default is conservative: it only pre-selects isolated for `inst_type` values known to require it (`EQUITY_PERP` / `EQUITY_PERPETUAL`). For any other instrument it defaults to cross, which you can flip with `M`.
+- For bracket orders on isolated-margin instruments, pass `--exec-inst ISOLATED_MARGIN` to `cdcx advanced create-otoco` the same way.


### PR DESCRIPTION
## Summary

Three related feature sets landing together:

- **Isolated margin + rejection-aware order flow** — adds M-toggle for isolated/cross margin, auto-attaches \`isolation_id\` from a live \`user.positions\` WS subscription, keeps the order modal open on exchange rejections (errors 617 / 623) with code-specific retry hints instead of silently treating rejections as success.
- **Close-position workflow (\`x\` on Positions tab)** — MARKET or LIMIT close, auto-derives reverse side, preserves \`qty_tick_size\` precision via raw quantity string, attaches \`REDUCE_ONLY\` and isolated-margin metadata when applicable.
- **client_oid origin tagging (\`cx1-\` / \`cx2-\` / \`cx3-\`)** — every order placed via CLI / MCP / TUI is tagged so downstream operators can bucket volume by channel with \`LEFT(cl_order_id, 3)\`. Undocumented \`CDCX_NO_ORIGIN_TAG=1\` escape hatch for power users with existing ID schemes.

Also widens \`t\` / \`o\` / \`O\` / \`c\` hotkey dispatch to Positions + Watchlist tabs, fixes cancel-order on Orders tab silently targeting BTC_USDT, and corrects Positions tab field parsing (side derived from sign of quantity, entry price derived from \`open_pos_cost / |quantity|\`).

## Changes

### New module: \`cdcx-core::origin\`
- \`OriginChannel\` enum (\`Cli\` / \`Mcp\` / \`Tui\`) with cx1/cx2/cx3 prefixes
- \`tag_client_oid\`, \`tag_params_in_place\`, \`tag_order_list_legs\` helpers
- ULID-style Crockford base32 time-ordered suffixes for Cassandra partition friendliness
- 36-char limit enforcement with stderr truncation warnings
- No double-prefixing (\`cx1-foo\` stays \`cx1-foo\` if re-tagged through MCP)
- 9 unit tests covering all branches + opt-out env var

### TUI user-stream infrastructure
- New \`UserStreamManager\` subscribing to \`user.positions\`, \`user.balance\`, \`user.order\` when authenticated
- \`AppState\` gains \`isolated_positions\` (instrument → isolation_id), \`positions_snapshot\`, \`user_connection\` status, and \`update_positions()\` helper that filters ISOLATED_MARGIN + non-zero-qty
- \`StreamEvent\` / \`DataEvent\` / \`ConnectionStatusEvent\` extended for the new channels
- \`apply_balance_records()\` extracted so WS pushes and REST responses share portfolio calc

### Workflow improvements
- \`Workflow::on_response\` trait method lets any workflow intercept the response shape for its \`submit()\` call (default: keep modal open — safer than the previous blanket-close behavior)
- \`PlaceOrderWorkflow\` gains Margin step, M hotkey, isolated-margin auto-default for \`EQUITY_PERP\`, Rejected step with error-code-specific hints
- New \`ClosePositionWorkflow\` at \`crates/cdcx-tui/src/workflows/close_position.rs\`

### Tab fixes
- \`OrdersTab::selected_instrument()\` added (was falling through to BTC_USDT default on cancel workflow)
- \`PositionsTab\` side derived from sign of quantity; entry price derived from \`open_pos_cost / |quantity|\`; quantity displayed as absolute value
- \`PositionsTab::selected_instrument()\` added for workflow targeting
- Watchlist + Positions footer help text updated with new hotkeys

### Skill
- \`skills/cdcx-isolated-margin.md\` — TUI M toggle / x close-position, CLI \`--exec-inst ISOLATED_MARGIN\`, \`margin transfer\`, \`margin leverage\`, error 617/623 recovery, end-to-end SPYUSD-PERP example

## Test plan

- [x] Workspace build (release): \`cargo build --release --bin cdcx\`
- [x] Workspace tests: 253 pass across all crates
- [x] Clippy: \`cargo clippy --workspace -- -D warnings\` clean
- [x] CLI dry-run tag smoke test: \`cdcx --dry-run trade order BUY BTC_USDT 0.001 --type LIMIT --price 50000\` → \`client_oid: cx1-01KPR...\`
- [x] CLI user-supplied oid tagging: \`--client-oid my-test-id\` → \`cx1-my-test-id\`
- [x] Opt-out: \`CDCX_NO_ORIGIN_TAG=1\` → \`client_oid\` unprefixed
- [x] TUI live-tested against a real SPYUSD-PERP position (isolated margin submission, error 617 recovery, error 623 recovery, close-position both MARKET and LIMIT)
- [ ] CI on PR branch
