### PR TITLE
ci(auto-release): dispatch release.yml instead of pushing tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,7 +1,15 @@
 name: Auto Release
 
-# Triggers when Cargo.toml version changes on main (e.g. after a version bump PR merges).
-# Checks if the version tag already exists — if not, creates it, which triggers release.yml.
+# Fires when Cargo.toml version changes on main (e.g. after a version-bump PR merges).
+# If the corresponding tag doesn't yet exist, this workflow dispatches release.yml with
+# the detected version. release.yml creates the tag itself on workflow_dispatch, then
+# runs the full test + multi-target build + publish pipeline.
+#
+# Why dispatch instead of pushing a tag here?
+#   Tag pushes authenticated by GITHUB_TOKEN do not trigger downstream workflows (GitHub's
+#   recursion-prevention rule). That silently breaks the tag -> release.yml chain, even
+#   though the tag shows up on the remote. workflow_dispatch is an explicit API call, not
+#   a push event, so the recursion block does not apply -- release.yml runs as intended.
 
 on:
   push:
@@ -10,7 +18,8 @@ on:
       - 'Cargo.toml'
 
 permissions:
-  contents: write
+  contents: read
+  actions: write  # required to dispatch release.yml
 
 jobs:
   maybe-release:
@@ -38,26 +47,31 @@ jobs:
             exit 1
           fi
 
-      - name: Check if tag already exists
+      - name: Check if release tag already exists on the remote
         id: check
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
+          # Query the API directly: a tag can exist locally in the fetched history
+          # without being the canonical release tag on GitHub, and vice versa. The API
+          # is the source of truth for "has this release already been cut".
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag $TAG already exists, skipping"
+            echo "Tag $TAG already exists on remote, skipping"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "Tag $TAG is new — will create release"
+            echo "Tag $TAG is new -- will dispatch release.yml"
           fi
 
-      - name: Create tag and trigger release
+      - name: Dispatch release workflow
         if: steps.check.outputs.exists == 'false'
         env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-          echo "::notice::Created tag $TAG — release workflow will start automatically"
+          gh workflow run release.yml \
+            --ref "$GITHUB_SHA" \
+            -f version="$VERSION"
+          echo "::notice::Dispatched release.yml for $TAG"


### PR DESCRIPTION
## Summary

Fix the silent failure in the `auto-release.yml` → `release.yml` chain. Tag pushes authenticated by `GITHUB_TOKEN` do not trigger downstream workflows (GitHub's recursion-prevention rule), so a version bump merge would create the `vX.Y.Z` tag on the remote but never produce a release. Discovered during the v1.1.1 cut — the tag landed, but `release.yml` never fired, so the release had to be re-cut manually by deleting the remote tag and re-pushing it under a human's credentials.

The fix: stop creating the tag in this workflow. Instead, `gh workflow run release.yml -f version=X.Y.Z --ref $GITHUB_SHA`. `release.yml` already has a `workflow_dispatch` code path that creates the tag itself, and since it's the *running* workflow at that point rather than a downstream trigger, the recursion block doesn't apply.

## Changes

- Replace `git tag` + `git push origin $TAG` with `gh workflow run release.yml`.
- Pin the dispatch to `$GITHUB_SHA` (the exact version-bump commit) so the Cargo.toml-vs-tag validation in `release.yml` is guaranteed to pass even if `main` advances between auto-release firing and the dispatch.
- Check tag existence via the GitHub API (`gh api repos/.../git/refs/tags/$TAG`) rather than `git rev-parse` on the local clone — the API is authoritative for "has this release already been cut".
- Tighten permissions: `contents: write` → `contents: read`, add `actions: write` (needed by `gh workflow run`).

## Why not use a PAT instead?

A PAT on the tag push would also work (`GITHUB_TOKEN` recursion block doesn't apply to PATs), but it adds secret management overhead and a rotation surface. The dispatch approach keeps everything within the default `GITHUB_TOKEN` and shrinks the blast radius.

## Test plan

- [ ] Merge, then at the next real version bump: confirm auto-release fires, dispatches `release.yml`, and a release is cut end-to-end.
- [ ] Belt-and-braces fallback preserved: manual tag push from a developer's credentials still triggers `release.yml` normally.