### PR TITLE
fix(cli): require explicit --type on trade order, never default to MARKET

### DIFF
--- a/crates/cdcx-cli/src/cli_builder.rs
+++ b/crates/cdcx-cli/src/cli_builder.rs
@@ -383,6 +383,47 @@ mod tests {
         assert!(sub_names.contains(&"mcp".to_string()));
     }
 
+    /// Regression: `schemas/trade.toml` used to carry `default = "MARKET"` for
+    /// the `type` param, which silently turned `cdcx trade order BUY INST QTY
+    /// --price P` into a MARKET order with an ignored price field. This test
+    /// pins the fix: without `--type`, the CLI must reject the command; with
+    /// `--type LIMIT`, it must parse and the payload must contain `LIMIT`.
+    #[test]
+    fn test_trade_order_requires_explicit_type() {
+        let registry =
+            SchemaRegistry::from_fixture_with_overlays().expect("fixture + overlays should parse");
+        let app = build_cli(&registry);
+
+        let missing_type = app.clone().try_get_matches_from([
+            "cdcx", "trade", "order", "BUY", "BTC_USDT", "0.0001", "--price", "710",
+        ]);
+        assert!(
+            missing_type.is_err(),
+            "trade order without --type must fail to parse — otherwise a missing flag becomes a market order"
+        );
+
+        let explicit_limit = app
+            .clone()
+            .try_get_matches_from([
+                "cdcx", "trade", "order", "BUY", "BTC_USDT", "0.0001", "--price", "710", "--type",
+                "LIMIT",
+            ])
+            .expect("trade order with --type LIMIT should parse");
+
+        let trade_sub = explicit_limit
+            .subcommand_matches("trade")
+            .and_then(|m| m.subcommand_matches("order"))
+            .expect("subcommand path");
+        let trade_endpoint = registry
+            .get_by_method("private/create-order")
+            .expect("private/create-order must be in registry");
+        let payload = extract_params(trade_sub, &trade_endpoint.params);
+        assert_eq!(
+            payload["type"], "LIMIT",
+            "payload type must echo the explicit --type value, not fall back to MARKET"
+        );
+    }
+
     #[test]
     fn test_build_cli_has_global_flags() {
         let registry = SchemaRegistry::from_fixture().expect("fixture spec should parse");

--- a/crates/cdcx-cli/tests/cli_smoke.rs
+++ b/crates/cdcx-cli/tests/cli_smoke.rs
@@ -384,9 +384,13 @@ fn test_positional_args_work() {
 }
 
 #[test]
-fn test_default_value_applied() {
+fn test_trade_order_rejects_missing_type() {
     require_spec!();
-    // Overlay: side=pos0, instrument_name=pos1, quantity=pos2, type default=MARKET
+    // Regression: the `type` param used to default to MARKET via the trade
+    // overlay, which silently promoted `--price` limit orders into market
+    // fills. The overlay now omits that default — per the OpenAPI spec,
+    // `type` is required with no server default. The CLI must refuse to
+    // submit the command, not silently pick the more destructive enum value.
     Command::cargo_bin("cdcx")
         .unwrap()
         .args([
@@ -400,8 +404,8 @@ fn test_default_value_applied() {
             "--dry-run",
         ])
         .assert()
-        .success()
-        .stdout(predicates::str::contains("private/create-order"));
+        .failure()
+        .stderr(predicates::str::contains("--type"));
 }
 
 #[test]

--- a/crates/cdcx-core/src/schema.rs
+++ b/crates/cdcx-core/src/schema.rs
@@ -112,6 +112,16 @@ impl SchemaRegistry {
         Self::from_openapi(spec).map_err(SchemaError::from)
     }
 
+    /// Same as `from_fixture`, but also applies the real production schema
+    /// overlays (schemas/*.toml). Used by tests that need to exercise the
+    /// fixture + overlay merge path — e.g. to assert that safety-critical
+    /// overlay decisions (required params, enum defaults) behave correctly.
+    pub fn from_fixture_with_overlays() -> Result<Self, SchemaError> {
+        let spec = include_str!("../../../tests/fixtures/test-spec.yaml");
+        let overlays = Self::load_overlays();
+        Self::from_openapi_with_overlay(spec, &overlays).map_err(SchemaError::from)
+    }
+
     fn load_overlays() -> Vec<OverlayGroup> {
         [
             include_str!("../../../schemas/market.toml"),

--- a/schemas/trade.toml
+++ b/schemas/trade.toml
@@ -21,9 +21,12 @@ position = 1
 name = "quantity"
 position = 2
 
+# `type` is required per the OpenAPI spec and has no server-side default.
+# We intentionally do NOT set `default = "MARKET"` here — silently defaulting a
+# trading CLI to the more destructive enum value turned limit orders (with
+# --price) into market fills when users forgot to pass --type.
 [[endpoints.params]]
 name = "type"
-default = "MARKET"
 
 [[endpoints]]
 method = "private/get-order-detail"


### PR DESCRIPTION
## Summary

**Safety bug.** The \`schemas/trade.toml\` overlay set \`default = \"MARKET\"\` for the \`type\` param on \`private/create-order\`. This turned commands like

\`\`\`
cdcx trade order BUY BTCUSD-PERP 0.0001 --price 710
\`\`\`

into \`{type: MARKET, price: \"710\", quantity: \"0.0001\", ...}\`. The exchange ignores \`price\` on MARKET orders, so what the user intended as a resting limit at 710 filled at the book top instead. Caught after two such orders fired on 0.0001 BTC test size.

The OpenAPI spec lists \`type\` as required (enum: \`LIMIT\` | \`MARKET\`) with no server-side default — the overlay default was a client-side choice that silently picked the more destructive enum value when users forgot the flag. Bad fit for a trading CLI.

## Changes

- **\`schemas/trade.toml\`** — drop \`default = \"MARKET\"\` on the \`type\` param; add a comment pinning the reason so it doesn't get re-added.
- **\`crates/cdcx-core/src/schema.rs\`** — add \`SchemaRegistry::from_fixture_with_overlays()\` so tests can exercise the fixture + overlay merge path. The existing \`from_fixture\` helper only loaded the spec and bypassed overlays, which meant bugs like this one couldn't be pinned by tests.
- **\`crates/cdcx-cli/src/cli_builder.rs\`** — add \`test_trade_order_requires_explicit_type\` regression: asserts the CLI rejects \`trade order\` without \`--type\`, and that \`--type LIMIT\` produces a payload with \`type: \"LIMIT\"\`.
- **\`crates/cdcx-cli/tests/cli_smoke.rs\`** — rename \`test_default_value_applied\` → \`test_trade_order_rejects_missing_type\` and flip the assertion. The smoke test was encoding the bug it's now pinning against.

## Behavior after this PR

Before:
\`\`\`
$ cdcx trade order BUY BTC_USDT 0.0001 --price 710 --dry-run
{ ... \"type\": \"MARKET\", \"price\": \"710\" ... }   # silent market fill
\`\`\`

After:
\`\`\`
$ cdcx trade order BUY BTC_USDT 0.0001 --price 710 --dry-run
error: the following required arguments were not provided:
  --type <type>

$ cdcx trade order BUY BTC_USDT 0.0001 --type LIMIT --price 710 --dry-run
{ ... \"type\": \"LIMIT\", \"price\": \"710\" ... }
\`\`\`

## Test plan

- [x] \`cargo test --workspace\` — all 256+ tests pass, including the two new regression tests.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- [x] Manual dry-run: missing \`--type\` rejected; \`--type LIMIT\` produces correct payload.
- [ ] After merge: optionally consider a follow-up that infers \`LIMIT\` when \`--price\` is passed without \`--type\`, as ergonomic sugar. Intentionally out of scope for this PR — explicit is safer than clever for order entry.

## Blast radius

- CLI only. No changes to the MCP server, TUI, or API client.
- Users who relied on the unstated \`MARKET\` default will now get a clap error instead of an unintended order — strictly safer.
- No breaking changes to any documented flow: the spec never allowed omitting \`type\`.