### PR TITLE
fix(tui): stream real-time updates to Orders, Positions and Portfolio tabs

### DIFF
--- a/crates/cdcx-core/src/env.rs
+++ b/crates/cdcx-core/src/env.rs
@@ -100,13 +100,22 @@ impl FromStr for Environment {
 mod tests {
     use super::*;
 
+    /// Covers both the unset-default URLs and the CDCX_* env-var overrides in
+    /// one sequential test. These used to live in two `#[test]` fns, but Rust
+    /// runs tests in parallel threads by default and `std::env::set_var` /
+    /// `remove_var` are process-global — so the override test's mid-flight
+    /// `set_var("CDCX_WS_USER_URL", ...)` would race the default test's read,
+    /// producing sporadic Windows CI failures (slower env syscalls amplify the
+    /// race). Collapsing into one test pins the set/read/remove cycles to a
+    /// single thread's timeline and removes the race without new dependencies.
     #[test]
-    fn test_environment_urls() {
-        // Clear any overrides that might be set
+    fn test_environment_urls_and_overrides() {
+        // Clear any overrides the environment might inject before we start.
         std::env::remove_var("CDCX_REST_URL");
         std::env::remove_var("CDCX_WS_MARKET_URL");
         std::env::remove_var("CDCX_WS_USER_URL");
 
+        // --- Defaults ---
         assert_eq!(
             Environment::Production.rest_url(),
             "https://api.crypto.com/exchange/v1"
@@ -131,10 +140,8 @@ mod tests {
             Environment::Uat.ws_user_url(),
             "wss://uat-stream.3ona.co/exchange/v1/user"
         );
-    }
 
-    #[test]
-    fn test_env_var_url_overrides() {
+        // --- Overrides (each sets, asserts, then restores before the next) ---
         std::env::set_var("CDCX_REST_URL", "https://custom-api.example.com/v1");
         assert_eq!(
             Environment::Production.rest_url(),

--- a/crates/cdcx-tui/src/app.rs
+++ b/crates/cdcx-tui/src/app.rs
@@ -664,6 +664,29 @@ impl App {
             }
         }
 
+        // User-channel events (positions, orders, balance) must reach their
+        // owning tabs even when a different tab is active — beta testers hit
+        // "refresh required" because we previously only delivered to the
+        // active tab. Route by TabKind so the tables stay live cross-tab.
+        let broadcast_kinds: &[TabKind] = match event {
+            DataEvent::OrdersUpdate(_) => &[TabKind::Orders],
+            DataEvent::PositionsSnapshot(_) => &[TabKind::Positions],
+            DataEvent::BalanceSnapshot(_) => &[TabKind::Portfolio],
+            _ => &[],
+        };
+        if !broadcast_kinds.is_empty() {
+            for kind in broadcast_kinds {
+                let idx = TabKind::ALL.iter().position(|k| k == kind);
+                if let Some(i) = idx {
+                    if i != self.active_tab {
+                        if let Some(tab) = self.tabs.get_mut(i) {
+                            tab.on_data(&event, &mut self.state);
+                        }
+                    }
+                }
+            }
+        }
+
         // Forward to active tab
         if let Some(tab) = self.tabs.get_mut(self.active_tab) {
             tab.on_data(&event, &mut self.state);

--- a/crates/cdcx-tui/src/tabs/orders.rs
+++ b/crates/cdcx-tui/src/tabs/orders.rs
@@ -10,7 +10,7 @@ use crate::tabs::{DataEvent, Tab};
 
 #[derive(Debug, Clone)]
 struct Order {
-    _order_id: String,
+    order_id: String,
     instrument: String,
     side: String,
     order_type: String,
@@ -18,6 +18,64 @@ struct Order {
     quantity: f64,
     filled_qty: f64,
     status: String,
+}
+
+fn is_terminal_status(status: &str) -> bool {
+    matches!(
+        status.to_ascii_uppercase().as_str(),
+        "FILLED" | "CANCELED" | "CANCELLED" | "REJECTED" | "EXPIRED"
+    )
+}
+
+fn parse_order_record(item: &serde_json::Value) -> Option<Order> {
+    let order_id = item
+        .get("order_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if order_id.is_empty() {
+        return None;
+    }
+    Some(Order {
+        order_id,
+        instrument: item
+            .get("instrument_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        side: item
+            .get("side")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        order_type: item
+            .get("order_type")
+            .or_else(|| item.get("type"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        price: item
+            .get("limit_price")
+            .or_else(|| item.get("price"))
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0),
+        quantity: item
+            .get("quantity")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0),
+        filled_qty: item
+            .get("cumulative_quantity")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0),
+        status: item
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+    })
 }
 
 pub struct OrdersTab {
@@ -58,7 +116,7 @@ impl OrdersTab {
                 .open_orders
                 .iter()
                 .map(|o| Order {
-                    _order_id: o.order_id.to_string(),
+                    order_id: o.order_id.to_string(),
                     instrument: o.instrument_name.clone(),
                     side: format!("{:?}", o.side).to_uppercase(),
                     order_type: format!("{:?}", o.order_type).to_uppercase(),
@@ -70,6 +128,33 @@ impl OrdersTab {
                 .collect();
             self.loaded = true;
         }
+    }
+
+    /// Apply a batch of order deltas from the `user.order` WS channel.
+    /// Terminal statuses remove the row; all others upsert by `order_id`.
+    fn apply_order_updates(&mut self, records: &[serde_json::Value]) {
+        for item in records {
+            let Some(order) = parse_order_record(item) else {
+                continue;
+            };
+            if is_terminal_status(&order.status) {
+                self.orders.retain(|o| o.order_id != order.order_id);
+                continue;
+            }
+            if let Some(existing) = self
+                .orders
+                .iter_mut()
+                .find(|o| o.order_id == order.order_id)
+            {
+                *existing = order;
+            } else {
+                self.orders.push(order);
+            }
+        }
+        if self.selected >= self.orders.len() {
+            self.selected = self.orders.len().saturating_sub(1);
+        }
+        self.loaded = true;
     }
 }
 
@@ -110,53 +195,14 @@ impl Tab for OrdersTab {
                 if let Some(arr) = arr_opt {
                     self.orders = arr
                         .iter()
-                        .map(|item| Order {
-                            _order_id: item
-                                .get("order_id")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            instrument: item
-                                .get("instrument_name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            side: item
-                                .get("side")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            order_type: item
-                                .get("order_type")
-                                .or_else(|| item.get("type"))
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            price: item
-                                .get("limit_price")
-                                .or_else(|| item.get("price"))
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse().ok())
-                                .unwrap_or(0.0),
-                            quantity: item
-                                .get("quantity")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse().ok())
-                                .unwrap_or(0.0),
-                            filled_qty: item
-                                .get("cumulative_quantity")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse().ok())
-                                .unwrap_or(0.0),
-                            status: item
-                                .get("status")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                        })
+                        .filter_map(parse_order_record)
+                        .filter(|o| !is_terminal_status(&o.status))
                         .collect();
                     self.loaded = true;
                 }
+            }
+            DataEvent::OrdersUpdate(records) => {
+                self.apply_order_updates(records);
             }
             _ => {
                 if !self.loaded {
@@ -304,7 +350,9 @@ impl Tab for OrdersTab {
     }
 
     fn on_activate(&mut self) {
-        self.loaded = false;
+        // Intentionally no-op: live state is kept in sync via user.order WS upserts,
+        // so we don't wipe the cache on tab switch. The initial REST prime runs
+        // automatically on first activation via the on_data fallthrough.
     }
 
     fn selected_instrument(&self) -> Option<&str> {

--- a/crates/cdcx-tui/src/tabs/portfolio.rs
+++ b/crates/cdcx-tui/src/tabs/portfolio.rs
@@ -17,6 +17,68 @@ struct Holding {
     value: f64, // market value in quote currency
 }
 
+fn is_stablecoin(symbol: &str) -> bool {
+    matches!(symbol, "USDT" | "USD" | "USDC" | "DAI" | "TUSD" | "BUSD")
+}
+
+/// Parse a single balance record into the static view fields. `value` is
+/// left at zero and filled by `recompute_holding_values` so the ticker-
+/// driven value recompute has a single writer (same pattern as Positions).
+fn parse_balance_record(item: &serde_json::Value) -> Option<Holding> {
+    let currency = item
+        .get("instrument_name")
+        .or_else(|| item.get("currency"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("?")
+        .to_string();
+
+    let amount = item
+        .get("total_cash_balance")
+        .or_else(|| item.get("quantity"))
+        .or_else(|| item.get("balance"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.0);
+    if amount <= 0.0 {
+        return None;
+    }
+
+    let available = item
+        .get("total_available_balance")
+        .or_else(|| item.get("available"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.0);
+
+    Some(Holding {
+        name: currency,
+        amount,
+        available,
+        value: 0.0,
+    })
+}
+
+/// Re-price every holding from `state.tickers`. Stablecoins are valued 1:1;
+/// non-stable holdings use `{SYM}_USDT` last ask. Called from REST, WS, and
+/// tick paths so holdings stay live between `user.balance` deltas (which
+/// only fire on trades/deposits, not on market price moves).
+fn recompute_holding_values(holdings: &mut [Holding], state: &AppState) -> (f64, f64) {
+    let mut cash_balance = 0.0;
+    let mut position_value = 0.0;
+    for h in holdings {
+        if is_stablecoin(&h.name) {
+            h.value = h.amount;
+            cash_balance += h.value;
+            continue;
+        }
+        let pair = format!("{}_USDT", h.name);
+        let last = state.tickers.get(&pair).map(|t| t.ask).unwrap_or(0.0);
+        h.value = h.amount * last;
+        position_value += h.value;
+    }
+    (cash_balance, position_value)
+}
+
 #[derive(Debug, Clone, Default)]
 struct PortfolioView {
     holdings: Vec<Holding>,
@@ -57,6 +119,49 @@ impl PortfolioTab {
                 is_private: true,
             });
         }
+    }
+
+    /// Shared between REST response and `user.balance` WS snapshot. Rebuilds
+    /// holdings from records, then runs the ticker-driven value recompute.
+    fn rebuild_from_records(&mut self, records: &[serde_json::Value], state: &mut AppState) {
+        let mut holdings: Vec<Holding> = records.iter().filter_map(parse_balance_record).collect();
+        let (cash_balance, position_value) = recompute_holding_values(&mut holdings, state);
+        holdings.sort_by(|a, b| b.value.partial_cmp(&a.value).unwrap());
+
+        let total_value = cash_balance + position_value;
+        if state.session_start_value.is_none() && total_value > 0.0 {
+            state.session_start_value = Some(total_value);
+        }
+        state.current_portfolio_value = total_value;
+
+        self.view = PortfolioView {
+            holdings,
+            cash_balance,
+            position_value,
+            total_value,
+            initial_value: state.session_start_value.unwrap_or(total_value),
+            unrealized_pnl: 0.0,
+            realized_pnl: 0.0,
+        };
+        self.loaded = true;
+    }
+
+    /// Re-run the ticker-based value pass on the existing holdings without
+    /// touching the payload-sourced amount/available fields. Called each
+    /// tick so values follow the market between `user.balance` deltas.
+    fn refresh_live_values(&mut self, state: &mut AppState) {
+        if self.view.holdings.is_empty() {
+            return;
+        }
+        let (cash_balance, position_value) =
+            recompute_holding_values(&mut self.view.holdings, state);
+        self.view.cash_balance = cash_balance;
+        self.view.position_value = position_value;
+        self.view.total_value = cash_balance + position_value;
+        state.current_portfolio_value = self.view.total_value;
+        self.view
+            .holdings
+            .sort_by(|a, b| b.value.partial_cmp(&a.value).unwrap());
     }
 
     fn build_paper_view(state: &AppState) -> PortfolioView {
@@ -166,98 +271,20 @@ impl Tab for PortfolioTab {
         match event {
             DataEvent::RestResponse { method, data } if method == "private/user-balance" => {
                 if let Some(arr) = data.get("data").and_then(|d| d.as_array()) {
-                    let mut holdings = Vec::new();
-                    let mut cash_balance = 0.0;
-                    let mut position_value = 0.0;
-
-                    for item in arr {
-                        let currency = item
-                            .get("instrument_name")
-                            .or_else(|| item.get("currency"))
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("?")
-                            .to_string();
-
-                        let total = item
-                            .get("total_cash_balance")
-                            .or_else(|| item.get("quantity"))
-                            .or_else(|| item.get("balance"))
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse().ok())
-                            .unwrap_or(0.0);
-
-                        let available = item
-                            .get("total_available_balance")
-                            .or_else(|| item.get("available"))
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse().ok())
-                            .unwrap_or(0.0);
-
-                        if total <= 0.0 {
-                            continue;
-                        }
-
-                        let is_stablecoin = matches!(
-                            currency.as_str(),
-                            "USDT" | "USD" | "USDC" | "DAI" | "TUSD" | "BUSD"
-                        );
-
-                        let value = item
-                            .get("market_value")
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse::<f64>().ok())
-                            .unwrap_or_else(|| {
-                                if is_stablecoin {
-                                    total
-                                } else {
-                                    let pair = format!("{}_USDT", currency);
-                                    state
-                                        .tickers
-                                        .get(&pair)
-                                        .map(|t| total * t.ask)
-                                        .unwrap_or(0.0)
-                                }
-                            });
-
-                        if is_stablecoin {
-                            cash_balance += value;
-                        } else {
-                            position_value += value;
-                        }
-                        holdings.push(Holding {
-                            name: currency,
-                            amount: total,
-                            available,
-                            value,
-                        });
-                    }
-
-                    holdings.sort_by(|a, b| b.value.partial_cmp(&a.value).unwrap());
-
-                    let total_value = cash_balance + position_value;
-
-                    // Track session start value for P&L
-                    if state.session_start_value.is_none() && total_value > 0.0 {
-                        state.session_start_value = Some(total_value);
-                    }
-                    state.current_portfolio_value = total_value;
-
-                    self.view = PortfolioView {
-                        holdings,
-                        cash_balance,
-                        position_value,
-                        total_value,
-                        initial_value: state.session_start_value.unwrap_or(total_value),
-                        unrealized_pnl: 0.0,
-                        realized_pnl: 0.0,
-                    };
-                    self.loaded = true;
+                    self.rebuild_from_records(arr, state);
                 }
+            }
+            DataEvent::BalanceSnapshot(records) => {
+                self.rebuild_from_records(records, state);
             }
             _ => {
                 if !self.loaded {
                     self.request_data(state);
+                    return;
                 }
+                // Keep non-stable holding values tracking the market between
+                // `user.balance` deltas (which only fire on trades/deposits).
+                self.refresh_live_values(state);
             }
         }
     }
@@ -480,6 +507,8 @@ impl Tab for PortfolioTab {
     }
 
     fn on_activate(&mut self) {
-        self.loaded = false;
+        // Intentionally no-op: state stays fresh via user.balance WS +
+        // per-tick ticker-driven value recompute, so wiping the cache on
+        // tab-switch only produces a blank frame before REST refills.
     }
 }

--- a/crates/cdcx-tui/src/tabs/positions.rs
+++ b/crates/cdcx-tui/src/tabs/positions.rs
@@ -94,6 +94,10 @@ impl PositionsTab {
             .iter()
             .filter_map(|item| parse_position_record(item, state))
             .collect();
+        // Immediately apply the same ticker-driven recompute the tick path uses,
+        // otherwise the WS payload's zero-initialised mark/pnl flashes on screen
+        // for one frame before the next tick fills it in.
+        apply_live_mark_and_pnl(&mut self.positions, state);
         if self.selected >= self.positions.len() {
             self.selected = self.positions.len().saturating_sub(1);
         }
@@ -101,10 +105,33 @@ impl PositionsTab {
     }
 }
 
+/// Overwrite `mark_price` and `pnl` on every position from the streaming
+/// ticker cache. Single source of truth for live values — called from both
+/// `rebuild_positions` (WS snapshot / REST response) and the tick fallthrough
+/// to avoid flicker between conflicting writers.
+fn apply_live_mark_and_pnl(positions: &mut [Position], state: &AppState) {
+    for pos in positions {
+        let Some(ticker) = state.tickers.get(&pos.instrument) else {
+            continue;
+        };
+        pos.mark_price = ticker.ask;
+        if pos.entry_price > 0.0 {
+            let direction = if pos.side == "BUY" || pos.side == "LONG" {
+                1.0
+            } else {
+                -1.0
+            };
+            pos.pnl = (pos.mark_price - pos.entry_price) * pos.quantity * direction;
+        }
+    }
+}
+
 /// Parse a single position record from the exchange into the row struct.
-/// Returns `None` for zero-quantity rows — the exchange echoes closed
-/// positions and we don't want them cluttering the table.
-fn parse_position_record(item: &serde_json::Value, state: &AppState) -> Option<Position> {
+/// Only static fields (instrument / side / qty / entry / liq) are read here;
+/// `mark_price` and `pnl` are owned exclusively by `apply_live_mark_and_pnl`
+/// so we have a single writer and no per-frame flicker. Returns `None` for
+/// zero-quantity rows — the exchange echoes closed positions.
+fn parse_position_record(item: &serde_json::Value, _state: &AppState) -> Option<Position> {
     let instrument = item
         .get("instrument_name")
         .and_then(|v| v.as_str())
@@ -161,19 +188,13 @@ fn parse_position_record(item: &serde_json::Value, state: &AppState) -> Option<P
         })
         .unwrap_or(0.0);
 
-    let mark = state.tickers.get(&instrument).map(|t| t.ask).unwrap_or(0.0);
-
     Some(Position {
         instrument,
         side,
         quantity: raw_qty.abs(),
         entry_price,
-        mark_price: mark,
-        pnl: item
-            .get("session_pnl")
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0.0),
+        mark_price: 0.0,
+        pnl: 0.0,
         liquidation_price: item
             .get("liquidation_price")
             .and_then(|v| v.as_str())
@@ -239,23 +260,8 @@ impl Tab for PositionsTab {
                 if !self.loaded {
                     self.request_data(state);
                 }
-                // Live update mark prices and P&L from streaming tickers
                 if self.loaded {
-                    for pos in &mut self.positions {
-                        if let Some(ticker) = state.tickers.get(&pos.instrument) {
-                            pos.mark_price = ticker.ask;
-                            // Calculate unrealized P&L: (mark - entry) * qty for LONG, inverse for SHORT
-                            let direction = if pos.side == "BUY" || pos.side == "LONG" {
-                                1.0
-                            } else {
-                                -1.0
-                            };
-                            if pos.entry_price > 0.0 {
-                                pos.pnl =
-                                    (pos.mark_price - pos.entry_price) * pos.quantity * direction;
-                            }
-                        }
-                    }
+                    apply_live_mark_and_pnl(&mut self.positions, state);
                 }
             }
         }

--- a/crates/cdcx-tui/src/tabs/positions.rs
+++ b/crates/cdcx-tui/src/tabs/positions.rs
@@ -85,6 +85,101 @@ impl PositionsTab {
             });
         }
     }
+
+    /// Rebuild the positions list from a raw records array — shared between
+    /// the REST response arm and the `user.positions` WS snapshot arm so the
+    /// field-parsing heuristics stay in one place.
+    fn rebuild_positions(&mut self, records: &[serde_json::Value], state: &AppState) {
+        self.positions = records
+            .iter()
+            .filter_map(|item| parse_position_record(item, state))
+            .collect();
+        if self.selected >= self.positions.len() {
+            self.selected = self.positions.len().saturating_sub(1);
+        }
+        self.loaded = true;
+    }
+}
+
+/// Parse a single position record from the exchange into the row struct.
+/// Returns `None` for zero-quantity rows — the exchange echoes closed
+/// positions and we don't want them cluttering the table.
+fn parse_position_record(item: &serde_json::Value, state: &AppState) -> Option<Position> {
+    let instrument = item
+        .get("instrument_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if instrument.is_empty() {
+        return None;
+    }
+
+    // The exchange encodes direction in the sign of `quantity`
+    // (positive = long, negative = short) and does NOT send an
+    // explicit `side` field on positions. Fall back to the
+    // quantity-sign convention when `side` is absent.
+    let raw_qty: f64 = item
+        .get("quantity")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.0);
+    if raw_qty.abs() < 1e-12 {
+        return None;
+    }
+    let side = item
+        .get("side")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            if raw_qty >= 0.0 {
+                "LONG".into()
+            } else {
+                "SHORT".into()
+            }
+        });
+
+    // The exchange returns `open_pos_cost` (total USD notional) rather than
+    // a per-unit `average_price`. Divide to recover the entry price. Fall
+    // back to `average_price` in case a future API version adds it directly.
+    let entry_price = item
+        .get("average_price")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|p| *p > 0.0)
+        .or_else(|| {
+            item.get("open_pos_cost")
+                .or_else(|| item.get("cost"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<f64>().ok())
+                .and_then(|cost| {
+                    if raw_qty.abs() > 0.0 {
+                        Some(cost.abs() / raw_qty.abs())
+                    } else {
+                        None
+                    }
+                })
+        })
+        .unwrap_or(0.0);
+
+    let mark = state.tickers.get(&instrument).map(|t| t.ask).unwrap_or(0.0);
+
+    Some(Position {
+        instrument,
+        side,
+        quantity: raw_qty.abs(),
+        entry_price,
+        mark_price: mark,
+        pnl: item
+            .get("session_pnl")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0),
+        liquidation_price: item
+            .get("liquidation_price")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0),
+    })
 }
 
 impl Tab for PositionsTab {
@@ -128,82 +223,13 @@ impl Tab for PositionsTab {
         match event {
             DataEvent::RestResponse { method, data } if method == "private/get-positions" => {
                 if let Some(arr) = data.get("data").and_then(|d| d.as_array()) {
-                    self.positions = arr
-                        .iter()
-                        .map(|item| {
-                            let instrument = item
-                                .get("instrument_name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string();
-                            let mark = state.tickers.get(&instrument).map(|t| t.ask).unwrap_or(0.0);
-
-                            // The exchange encodes direction in the sign of `quantity`
-                            // (positive = long, negative = short) and does NOT send an
-                            // explicit `side` field on positions. Fall back to the
-                            // quantity-sign convention when `side` is absent.
-                            let raw_qty: f64 = item
-                                .get("quantity")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse().ok())
-                                .unwrap_or(0.0);
-                            let side = item
-                                .get("side")
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string())
-                                .unwrap_or_else(|| {
-                                    if raw_qty >= 0.0 {
-                                        "LONG".into()
-                                    } else {
-                                        "SHORT".into()
-                                    }
-                                });
-
-                            // The exchange returns `open_pos_cost` (total USD notional)
-                            // rather than a per-unit `average_price`. Divide to recover
-                            // the entry price. Fall back to `average_price` in case a
-                            // future API version adds it directly.
-                            let entry_price = item
-                                .get("average_price")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse::<f64>().ok())
-                                .filter(|p| *p > 0.0)
-                                .or_else(|| {
-                                    item.get("open_pos_cost")
-                                        .or_else(|| item.get("cost"))
-                                        .and_then(|v| v.as_str())
-                                        .and_then(|s| s.parse::<f64>().ok())
-                                        .and_then(|cost| {
-                                            if raw_qty.abs() > 0.0 {
-                                                Some(cost.abs() / raw_qty.abs())
-                                            } else {
-                                                None
-                                            }
-                                        })
-                                })
-                                .unwrap_or(0.0);
-
-                            Position {
-                                instrument,
-                                side,
-                                quantity: raw_qty.abs(),
-                                entry_price,
-                                mark_price: mark,
-                                pnl: item
-                                    .get("session_pnl")
-                                    .and_then(|v| v.as_str())
-                                    .and_then(|s| s.parse().ok())
-                                    .unwrap_or(0.0),
-                                liquidation_price: item
-                                    .get("liquidation_price")
-                                    .and_then(|v| v.as_str())
-                                    .and_then(|s| s.parse().ok())
-                                    .unwrap_or(0.0),
-                            }
-                        })
-                        .collect();
-                    self.loaded = true;
+                    self.rebuild_positions(arr, state);
                 }
+            }
+            DataEvent::PositionsSnapshot(records) => {
+                // `user.positions` sends the full open-position set on each
+                // delta, so replace wholesale — matches AppState::update_positions.
+                self.rebuild_positions(records, state);
             }
             _ => {
                 if state.paper_mode {
@@ -384,7 +410,9 @@ impl Tab for PositionsTab {
     }
 
     fn on_activate(&mut self) {
-        self.loaded = false;
+        // Intentionally no-op: size/entry/liq stay current via user.positions
+        // snapshots, and mark/P&L recompute every tick from state.tickers.
+        // The initial REST prime runs on first activation via the fallthrough.
     }
 
     fn selected_instrument(&self) -> Option<&str> {


### PR DESCRIPTION
## Summary

Beta testers reported that Orders required a manual refresh to see fresh data, and Positions only updated mark price / P&L live while Size stayed frozen until `r` was pressed. Investigation surfaced the same class of bug on Portfolio (holdings stale between 30s REST refreshes).

Root cause: the `UserStreamManager` already subscribed to `user.order`, `user.positions`, and `user.balance`, and `lib.rs` already dispatched them as `DataEvent`s, but:

1. `App::on_data` forwarded events only to the *active* tab, so user-channel deltas to Orders/Positions/Portfolio were dropped whenever another tab was visible.
2. `OrdersTab`, `PositionsTab`, and `PortfolioTab` had no match arms for their respective `DataEvent` variants, so even when active they silently discarded the WS updates.
3. `on_activate` reset `loaded` on every tab switch, forcing a REST round-trip and a "loading..." flash.

## Commits

- **`df136d0` — Orders and Positions wiring.** Broadcast `OrdersUpdate` / `PositionsSnapshot` / `BalanceSnapshot` to their owning tabs via `TabKind` lookup regardless of active tab. `OrdersTab` upserts by `order_id` and removes on terminal statuses (`FILLED` / `CANCELED` / `CANCELLED` / `REJECTED` / `EXPIRED`), sharing one parser between REST and WS paths. `PositionsTab` replaces the positions vec on each `user.positions` snapshot so Size / Entry / Liq track live.
- **`404d4f3` — Positions flicker fix.** The previous commit left two writers racing for `mark_price` / `pnl` (payload-sourced on WS snapshot, ticker-recomputed on tick), producing a visible `0.00 → 1.23 → 0.00 → 1.24` flash. Extracted a single `apply_live_mark_and_pnl` helper owning those fields; `parse_position_record` now only sets static fields.
- **`14b50c7` — Portfolio tab.** Same pattern applied: handle `BalanceSnapshot`, split parsing (`parse_balance_record`) from valuation (`recompute_holding_values`), call recompute from REST + WS + tick paths so non-stable holdings follow the market between `user.balance` deltas (which only fire on trades/deposits).
- **`05985a7` — Windows CI race fix.** Collapse `test_environment_urls` and `test_env_var_url_overrides` into one sequential test. Both mutated process-global `CDCX_*` env vars and Rust's default parallel test harness raced them on Windows (slower env syscalls amplify the window). One test, one thread, race closed by construction. No new deps.

All three TUI tabs drop their `on_activate` resets — WS + tick recompute keep state current.

## Test plan

- [x] `cdcx tui` → tab **3 Orders**: open a limit order via CLI/another client, confirm it appears in the table without pressing `r`; cancel it and confirm the row disappears.
- [x] Tab **6 Positions**: open or modify a position, confirm Size/Entry update live; observe mark price / P&L tick smoothly with no `0.00` flash on `user.positions` deltas.
- [x] Tab **2 Portfolio**: place a trade that changes balances, confirm holdings update without refresh; watch non-stable holding USD values tick with the Market tab.
- [x] Switch between tabs rapidly — no "loading..." flash on re-entry.
- [x] `cargo test --workspace` passes locally; Windows CI race fix verified via 10-run loop.