### PR TITLE
fix(tui): use format_price and skip 0 in price fallback chain

### DIFF
--- a/crates/cdcx-tui/src/tabs/history.rs
+++ b/crates/cdcx-tui/src/tabs/history.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Paragraph, Row, Table};
 use ratatui::Frame;
 
+use crate::format::format_price;
 use crate::state::{AppState, RestRequest};
 use crate::tabs::{DataEvent, Tab};
 
@@ -15,7 +16,7 @@ struct HistoryOrder {
     instrument: String,
     side: String,
     order_type: String,
-    price: f64,
+    price: String,
     quantity: f64,
     status: String,
     time: String,
@@ -68,7 +69,7 @@ impl HistoryTab {
                         instrument: t.instrument_name.clone(),
                         side: format!("{:?}", t.side).to_uppercase(),
                         order_type: "MARKET".into(), // paper trades are always filled
-                        price: t.price,
+                        price: format_price(t.price),
                         quantity: t.quantity,
                         status: "FILLED".into(),
                         time: t.timestamp.chars().take(19).collect(), // trim to datetime
@@ -149,13 +150,23 @@ impl Tab for HistoryTab {
                                 .and_then(|v| v.as_str())
                                 .unwrap_or("")
                                 .to_string(),
-                            price: item
-                                .get("avg_price")
-                                .or_else(|| item.get("limit_price"))
-                                .or_else(|| item.get("price"))
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse().ok())
-                                .unwrap_or(0.0),
+                            price: format_price(
+                                item.get("avg_price")
+                                    .and_then(|v| v.as_str())
+                                    .filter(|s| *s != "0")
+                                    .or_else(|| {
+                                        item.get("limit_price")
+                                            .and_then(|v| v.as_str())
+                                            .filter(|s| *s != "0")
+                                    })
+                                    .or_else(|| {
+                                        item.get("price")
+                                            .and_then(|v| v.as_str())
+                                            .filter(|s| *s != "0")
+                                    })
+                                    .and_then(|s| s.parse().ok())
+                                    .unwrap_or(0.0),
+                            ),
                             quantity: item
                                 .get("quantity")
                                 .and_then(|v| v.as_str())
@@ -279,11 +290,7 @@ impl Tab for HistoryTab {
                             Cell::from(o.instrument.as_str()),
                             Cell::from(o.side.as_str()),
                             Cell::from(o.order_type.as_str()),
-                            Cell::from(if o.price > 0.0 {
-                                format!("{:.2}", o.price)
-                            } else {
-                                "MARKET".into()
-                            }),
+                            Cell::from(o.price.as_str()),
                             Cell::from(format!("{:.4}", o.quantity)),
                             Cell::from(o.status.as_str()),
                             Cell::from(o.time.as_str()),
@@ -294,11 +301,7 @@ impl Tab for HistoryTab {
                             Cell::from(o.instrument.as_str()),
                             Cell::from(o.side.as_str()).style(Style::default().fg(side_color)),
                             Cell::from(o.order_type.as_str()),
-                            Cell::from(if o.price > 0.0 {
-                                format!("{:.2}", o.price)
-                            } else {
-                                "MARKET".into()
-                            }),
+                            Cell::from(o.price.as_str()),
                             Cell::from(format!("{:.4}", o.quantity)),
                             Cell::from(o.status.as_str()).style(Style::default().fg(status_color)),
                             Cell::from(o.time.as_str())

--- a/crates/cdcx-tui/src/tabs/orders.rs
+++ b/crates/cdcx-tui/src/tabs/orders.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Paragraph, Row, Table};
 use ratatui::Frame;
 
+use crate::format::format_price;
 use crate::state::{AppState, RestRequest};
 use crate::tabs::{DataEvent, Tab};
 
@@ -14,7 +15,7 @@ struct Order {
     instrument: String,
     side: String,
     order_type: String,
-    price: f64,
+    price: String,
     quantity: f64,
     filled_qty: f64,
     status: String,
@@ -54,12 +55,18 @@ fn parse_order_record(item: &serde_json::Value) -> Option<Order> {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string(),
-        price: item
-            .get("limit_price")
-            .or_else(|| item.get("price"))
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0.0),
+        price: format_price(
+            item.get("limit_price")
+                .and_then(|v| v.as_str())
+                .filter(|s| *s != "0")
+                .or_else(|| {
+                    item.get("price")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| *s != "0")
+                })
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0.0),
+        ),
         quantity: item
             .get("quantity")
             .and_then(|v| v.as_str())
@@ -120,7 +127,7 @@ impl OrdersTab {
                     instrument: o.instrument_name.clone(),
                     side: format!("{:?}", o.side).to_uppercase(),
                     order_type: format!("{:?}", o.order_type).to_uppercase(),
-                    price: o.price.unwrap_or(0.0),
+                    price: format_price(o.price.unwrap_or(0.0)),
                     quantity: o.quantity,
                     filled_qty: 0.0,
                     status: format!("{:?}", o.status).to_uppercase(),
@@ -301,11 +308,7 @@ impl Tab for OrdersTab {
                             Cell::from(o.instrument.as_str()),
                             Cell::from(o.side.as_str()),
                             Cell::from(o.order_type.as_str()),
-                            Cell::from(if o.price > 0.0 {
-                                format!("{:.2}", o.price)
-                            } else {
-                                "MARKET".into()
-                            }),
+                            Cell::from(o.price.as_str()),
                             Cell::from(format!("{:.4}", o.quantity)),
                             Cell::from(format!("{:.1}%", fill_pct)),
                             Cell::from(o.status.as_str()),
@@ -316,11 +319,7 @@ impl Tab for OrdersTab {
                             Cell::from(o.instrument.as_str()),
                             Cell::from(o.side.as_str()).style(Style::default().fg(side_color)),
                             Cell::from(o.order_type.as_str()),
-                            Cell::from(if o.price > 0.0 {
-                                format!("{:.2}", o.price)
-                            } else {
-                                "MARKET".into()
-                            }),
+                            Cell::from(o.price.as_str()),
                             Cell::from(format!("{:.4}", o.quantity)),
                             Cell::from(format!("{:.1}%", fill_pct)),
                             Cell::from(o.status.as_str()).style(Style::default().fg(status_color)),


### PR DESCRIPTION
## Summary
- When the API returns `avg_price` or `limit_price` as `"0"`, the fallback chain now skips to the next field instead of displaying a zero price
- Replaced inline `if price > 0.0 { format!("{:.2}") } else { "MARKET" }` with `format_price()` for consistent display (comma separators, adaptive decimals)
- Changed `price` field from `f64` to `String` on both `HistoryOrder` and `Order` structs since it's only used for display

## Test plan
- [x] Verify market orders (no limit price) show `—` instead of `MARKET`
- [x] Verify orders with `avg_price: "0"` correctly fall back to `limit_price`
- [x] Verify orders with both `avg_price: "0"` and `limit_price: "0"` fall back to `price`
- [x] Verify large prices display with comma separators (e.g. `1,234.56`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)