### PR TITLE
feat: self-update system with CLI command and TUI integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,6 +2218,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2242,12 +2243,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -3443,6 +3446,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/cdcx-cli/src/cli_builder.rs
+++ b/crates/cdcx-cli/src/cli_builder.rs
@@ -187,6 +187,18 @@ pub fn build_static_cli() -> clap::Command {
             ),
     );
 
+    // Update subcommand
+    app = app.subcommand(
+        clap::Command::new("update")
+            .about("Check for and install updates")
+            .arg(
+                clap::Arg::new("check")
+                    .long("check")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Only check for updates, don't install"),
+            ),
+    );
+
     app
 }
 

--- a/crates/cdcx-cli/src/dispatch.rs
+++ b/crates/cdcx-cli/src/dispatch.rs
@@ -532,6 +532,69 @@ pub async fn run_stream(
     Ok(serde_json::json!({"stream": "completed"}))
 }
 
+pub async fn run_update(check_only: bool) -> Result<(), CdcxError> {
+    use cdcx_core::update::{download_and_install, is_newer, UpdateChecker};
+
+    let current = env!("CARGO_PKG_VERSION");
+    eprintln!("Current version: {}", current);
+    eprintln!("Checking for updates...");
+
+    let checker = UpdateChecker::default();
+    let info = checker
+        .fetch_latest()
+        .await
+        .map_err(|_| CdcxError::Config("Check updates failed, try again later".into()))?;
+
+    if !is_newer(&info.version, current) {
+        eprintln!("Already up to date ({})", current);
+        return Ok(());
+    }
+
+    eprintln!("New version available: {} → {}", current, info.version);
+
+    if check_only {
+        eprintln!("Release: {}", info.html_url);
+        return Ok(());
+    }
+
+    if info.download_url.is_none() {
+        eprintln!(
+            "No pre-built binary for {} — download manually:",
+            cdcx_core::update::current_target()
+        );
+        eprintln!("  {}", info.html_url);
+        return Ok(());
+    }
+
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stderr());
+    if is_tty {
+        eprint!("Install version {}? [y/N] ", info.version);
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(CdcxError::Io)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            eprintln!("Update cancelled.");
+            return Ok(());
+        }
+    }
+
+    eprintln!(
+        "Downloading {}...",
+        info.asset_name.as_deref().unwrap_or("update")
+    );
+
+    download_and_install(&info)
+        .await
+        .map_err(|e| CdcxError::Config(format!("Update failed: {e}")))?;
+
+    eprintln!(
+        "Updated to {} — restart cdcx to use the new version.",
+        info.version
+    );
+    Ok(())
+}
+
 pub async fn run_mcp(
     services: String,
     allow_dangerous: bool,

--- a/crates/cdcx-cli/src/main.rs
+++ b/crates/cdcx-cli/src/main.rs
@@ -70,6 +70,24 @@ async fn main() {
         }
     }
 
+    // Background update check — fire-and-forget, throttled to once per day.
+    {
+        let checker = cdcx_core::update::UpdateChecker::default();
+        if checker.should_check() {
+            tokio::spawn(async move {
+                if let Ok(info) = checker.fetch_latest().await {
+                    let current = env!("CARGO_PKG_VERSION");
+                    if cdcx_core::update::is_newer(&info.version, current) {
+                        eprintln!(
+                            "\nUpdate available: {} → {} — run `cdcx update` to install\n",
+                            current, info.version,
+                        );
+                    }
+                }
+            });
+        }
+    }
+
     let global = GlobalFlags::from_arg_matches(&matches).expect("Failed to parse global flags");
     let format = OutputFormat::resolve(global.output.as_deref());
 
@@ -151,6 +169,16 @@ async fn main() {
             if let Err(e) = groups::setup::run_setup().await {
                 eprintln!("{}", format_error(&e.to_envelope(), format));
                 std::process::exit(1);
+            }
+        }
+        Some(("update", sub)) => {
+            let check_only = sub.get_flag("check");
+            match dispatch::run_update(check_only).await {
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("{}", format_error(&e.to_envelope(), format));
+                    std::process::exit(1);
+                }
             }
         }
         Some(("mcp", sub)) => {

--- a/crates/cdcx-core/Cargo.toml
+++ b/crates/cdcx-core/Cargo.toml
@@ -25,11 +25,11 @@ serde_yaml = "0.9"
 # ── TLS: rustls on Linux (cross-compile friendly), native-tls elsewhere ──
 
 [target.'cfg(target_os = "linux")'.dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 
 [dev-dependencies]

--- a/crates/cdcx-core/src/lib.rs
+++ b/crates/cdcx-core/src/lib.rs
@@ -12,4 +12,5 @@ pub mod sanitize;
 pub mod schema;
 pub mod signing;
 pub mod tables;
+pub mod update;
 pub mod ws_client;

--- a/crates/cdcx-core/src/update.rs
+++ b/crates/cdcx-core/src/update.rs
@@ -1,0 +1,487 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+fn releases_api_url() -> String {
+    let repo = env!("CARGO_PKG_REPOSITORY");
+    let owner_repo = repo.strip_prefix("https://github.com/").unwrap();
+    format!(
+        "https://api.github.com/repos/{}/releases/latest",
+        owner_repo
+    )
+}
+
+fn releases_html_url() -> String {
+    format!("{}/releases/latest", env!("CARGO_PKG_REPOSITORY"))
+}
+
+pub struct UpdateChecker {
+    meta_path: PathBuf,
+    ttl: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReleaseInfo {
+    pub version: String,
+    pub download_url: Option<String>,
+    pub asset_name: Option<String>,
+    pub html_url: String,
+}
+
+impl Default for UpdateChecker {
+    fn default() -> Self {
+        let cache_dir = dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("cdcx");
+        Self {
+            meta_path: cache_dir.join("update-meta.json"),
+            ttl: Duration::from_secs(86400),
+        }
+    }
+}
+
+impl UpdateChecker {
+    pub fn should_check(&self) -> bool {
+        let Ok(content) = fs::read_to_string(&self.meta_path) else {
+            return true;
+        };
+        let Ok(meta) = serde_json::from_str::<serde_json::Value>(&content) else {
+            return true;
+        };
+        let Some(checked_at) = meta["checked_at"].as_str() else {
+            return true;
+        };
+        let Ok(checked_time) = chrono::DateTime::parse_from_rfc3339(checked_at) else {
+            return true;
+        };
+        let elapsed = chrono::Utc::now().signed_duration_since(checked_time);
+        elapsed.num_seconds() > self.ttl.as_secs() as i64
+    }
+
+    pub async fn fetch_latest(&self) -> Result<ReleaseInfo, UpdateError> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .user_agent("cdcx-cli")
+            .build()
+            .map_err(|e| UpdateError(format!("HTTP client error: {e}")))?;
+
+        let resp: serde_json::Value = client
+            .get(releases_api_url())
+            .send()
+            .await
+            .map_err(|e| UpdateError(format!("Failed to check for updates: {e}")))?
+            .json()
+            .await
+            .map_err(|e| UpdateError(format!("Failed to parse release info: {e}")))?;
+
+        let tag = resp["tag_name"]
+            .as_str()
+            .ok_or_else(|| UpdateError("No tag_name in release".into()))?;
+        let version = tag.strip_prefix('v').unwrap_or(tag).to_string();
+
+        let html_url = resp["html_url"]
+            .as_str()
+            .map(String::from)
+            .unwrap_or_else(releases_html_url);
+
+        let target = current_target();
+        let (download_url, asset_name) = if let Some(assets) = resp["assets"].as_array() {
+            find_asset(assets, &version, target)
+        } else {
+            (None, None)
+        };
+
+        let info = ReleaseInfo {
+            version,
+            download_url,
+            asset_name,
+            html_url,
+        };
+
+        self.save_meta(&info);
+        Ok(info)
+    }
+
+    pub fn cached_release_info(&self) -> Option<ReleaseInfo> {
+        let content = fs::read_to_string(&self.meta_path).ok()?;
+        let meta: serde_json::Value = serde_json::from_str(&content).ok()?;
+        let version = meta["latest_version"].as_str()?;
+        Some(ReleaseInfo {
+            version: version.to_string(),
+            download_url: meta["download_url"].as_str().map(String::from),
+            asset_name: meta["asset_name"].as_str().map(String::from),
+            html_url: meta["html_url"]
+                .as_str()
+                .map(String::from)
+                .unwrap_or_else(releases_html_url),
+        })
+    }
+
+    fn save_meta(&self, info: &ReleaseInfo) {
+        let meta = serde_json::json!({
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "latest_version": info.version,
+            "download_url": info.download_url,
+            "asset_name": info.asset_name,
+            "html_url": info.html_url,
+        });
+        if let Some(parent) = self.meta_path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::write(
+            &self.meta_path,
+            serde_json::to_string_pretty(&meta).unwrap_or_default(),
+        );
+    }
+}
+
+/// Progress update sent during download.
+#[derive(Debug, Clone)]
+pub enum UpdateProgress {
+    Downloading { downloaded: u64, total: Option<u64> },
+    Extracting,
+    Installing,
+    Done,
+    Failed(String),
+}
+
+pub async fn download_and_install(info: &ReleaseInfo) -> Result<(), UpdateError> {
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    download_and_install_with_progress(info, tx).await
+}
+
+pub async fn download_and_install_with_progress(
+    info: &ReleaseInfo,
+    progress: tokio::sync::mpsc::UnboundedSender<UpdateProgress>,
+) -> Result<(), UpdateError> {
+    use futures_util::StreamExt;
+
+    let download_url = info
+        .download_url
+        .as_ref()
+        .ok_or_else(|| UpdateError("No download URL available for this platform".into()))?;
+
+    let current_exe = std::env::current_exe()
+        .map_err(|e| UpdateError(format!("Cannot determine current binary path: {e}")))?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .user_agent("cdcx-cli")
+        .build()
+        .map_err(|e| UpdateError(format!("HTTP client error: {e}")))?;
+
+    let tmp_dir = std::env::temp_dir().join("cdcx-update");
+    let _ = fs::remove_dir_all(&tmp_dir);
+    fs::create_dir_all(&tmp_dir)
+        .map_err(|e| UpdateError(format!("Failed to create temp dir: {e}")))?;
+
+    let asset_name = info.asset_name.as_deref().unwrap_or("archive");
+    let archive_path = tmp_dir.join(asset_name);
+
+    let resp = client
+        .get(download_url)
+        .send()
+        .await
+        .map_err(|e| UpdateError(format!("Download failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        return Err(UpdateError(format!(
+            "Download failed: HTTP {}",
+            resp.status()
+        )));
+    }
+
+    let total = resp.content_length();
+    let mut downloaded: u64 = 0;
+    let mut body = resp.bytes_stream();
+    let mut file_bytes: Vec<u8> = Vec::with_capacity(total.unwrap_or(0) as usize);
+
+    while let Some(chunk) = body.next().await {
+        let chunk = chunk.map_err(|e| UpdateError(format!("Download error: {e}")))?;
+        downloaded += chunk.len() as u64;
+        file_bytes.extend_from_slice(&chunk);
+        let _ = progress.send(UpdateProgress::Downloading { downloaded, total });
+    }
+
+    let _ = progress.send(UpdateProgress::Extracting);
+
+    fs::write(&archive_path, &file_bytes)
+        .map_err(|e| UpdateError(format!("Failed to write archive: {e}")))?;
+
+    let extract_dir = tmp_dir.join("extracted");
+    fs::create_dir_all(&extract_dir)
+        .map_err(|e| UpdateError(format!("Failed to create extract dir: {e}")))?;
+
+    extract_archive(&archive_path, &extract_dir, asset_name)?;
+
+    let _ = progress.send(UpdateProgress::Installing);
+
+    let binary_name = if cfg!(windows) { "cdcx.exe" } else { "cdcx" };
+    let new_binary = find_binary_in_dir(&extract_dir, binary_name)?;
+
+    replace_binary(&new_binary, &current_exe)?;
+
+    let _ = fs::remove_dir_all(&tmp_dir);
+    let _ = progress.send(UpdateProgress::Done);
+    Ok(())
+}
+
+fn extract_archive(
+    archive_path: &Path,
+    extract_dir: &Path,
+    asset_name: &str,
+) -> Result<(), UpdateError> {
+    let status = if cfg!(windows) && asset_name.ends_with(".zip") {
+        std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!(
+                    "Expand-Archive -Path '{}' -DestinationPath '{}' -Force",
+                    archive_path.display(),
+                    extract_dir.display()
+                ),
+            ])
+            .status()
+    } else {
+        let args = if asset_name.ends_with(".zip") {
+            vec!["xf"]
+        } else {
+            vec!["xzf"]
+        };
+        std::process::Command::new("tar")
+            .args(args)
+            .arg(archive_path)
+            .arg("-C")
+            .arg(extract_dir)
+            .status()
+    }
+    .map_err(|e| UpdateError(format!("Failed to extract archive: {e}")))?;
+
+    if !status.success() {
+        return Err(UpdateError("Archive extraction failed".into()));
+    }
+    Ok(())
+}
+
+fn find_binary_in_dir(dir: &Path, name: &str) -> Result<PathBuf, UpdateError> {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() && path.file_name().map(|n| n == name).unwrap_or(false) {
+                return Ok(path);
+            }
+            if path.is_dir() {
+                if let Ok(found) = find_binary_in_dir(&path, name) {
+                    return Ok(found);
+                }
+            }
+        }
+    }
+    Err(UpdateError(format!("Binary '{name}' not found in archive")))
+}
+
+fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<(), UpdateError> {
+    // Copy to a temp file in the same directory as the target (guarantees same mount point)
+    let tmp_dest = current_exe.with_file_name(".cdcx.update.tmp");
+
+    fs::copy(new_binary, &tmp_dest)
+        .map_err(|e| UpdateError(format!("Failed to copy new binary: {e}")))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&tmp_dest, fs::Permissions::from_mode(0o755));
+    }
+
+    #[cfg(not(windows))]
+    {
+        fs::rename(&tmp_dest, current_exe).map_err(|e| {
+            let _ = fs::remove_file(&tmp_dest);
+            UpdateError(format!("Failed to replace binary: {e}"))
+        })?;
+    }
+
+    #[cfg(windows)]
+    {
+        let old_path = current_exe.with_extension("exe.old");
+        let _ = fs::remove_file(&old_path);
+        fs::rename(current_exe, &old_path).map_err(|e| {
+            let _ = fs::remove_file(&tmp_dest);
+            UpdateError(format!("Failed to move old binary: {e}"))
+        })?;
+        if let Err(e) = fs::rename(&tmp_dest, current_exe) {
+            let _ = fs::rename(&old_path, current_exe);
+            let _ = fs::remove_file(&tmp_dest);
+            return Err(UpdateError(format!("Failed to place new binary: {e}")));
+        }
+    }
+
+    Ok(())
+}
+
+fn find_asset(
+    assets: &[serde_json::Value],
+    version: &str,
+    target: &str,
+) -> (Option<String>, Option<String>) {
+    let expected_prefix = format!("cdcx-{version}-{target}");
+    for asset in assets {
+        if let Some(name) = asset["name"].as_str() {
+            if name.starts_with(&expected_prefix)
+                && (name.ends_with(".tar.gz") || name.ends_with(".zip"))
+                && !name.ends_with(".sha256")
+            {
+                let url = asset["browser_download_url"].as_str().map(String::from);
+                return (url, Some(name.to_string()));
+            }
+        }
+    }
+    (None, None)
+}
+
+pub fn current_target() -> &'static str {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "x86_64-unknown-linux-musl"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "aarch64-unknown-linux-musl"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        "x86_64-apple-darwin"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "aarch64-apple-darwin"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        "x86_64-pc-windows-msvc"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        "aarch64-pc-windows-msvc"
+    }
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64"),
+    )))]
+    {
+        "unknown"
+    }
+}
+
+fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
+    let s = s.strip_prefix('v').unwrap_or(s);
+    let parts: Vec<&str> = s.splitn(3, '.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let patch_str = parts[2].split('-').next().unwrap_or(parts[2]);
+    Some((
+        parts[0].parse().ok()?,
+        parts[1].parse().ok()?,
+        patch_str.parse().ok()?,
+    ))
+}
+
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    match (parse_semver(latest), parse_semver(current)) {
+        (Some(l), Some(c)) => l > c,
+        _ => false,
+    }
+}
+
+#[derive(Debug)]
+pub struct UpdateError(pub String);
+
+impl std::fmt::Display for UpdateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for UpdateError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_semver() {
+        assert_eq!(parse_semver("1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("v1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("1.2.3-rc1"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("invalid"), None);
+        assert_eq!(parse_semver("1.2"), None);
+    }
+
+    #[test]
+    fn test_is_newer() {
+        assert!(is_newer("1.2.0", "1.1.1"));
+        assert!(is_newer("2.0.0", "1.9.9"));
+        assert!(is_newer("1.1.2", "1.1.1"));
+        assert!(!is_newer("1.1.1", "1.1.1"));
+        assert!(!is_newer("1.0.0", "1.1.1"));
+        assert!(!is_newer("invalid", "1.1.1"));
+    }
+
+    #[test]
+    fn test_current_target_is_known() {
+        assert_ne!(current_target(), "unknown");
+    }
+
+    #[test]
+    fn test_find_asset_matches() {
+        let assets = vec![
+            serde_json::json!({
+                "name": "cdcx-1.2.0-x86_64-apple-darwin.tar.gz",
+                "browser_download_url": "https://example.com/cdcx-1.2.0-x86_64-apple-darwin.tar.gz"
+            }),
+            serde_json::json!({
+                "name": "cdcx-1.2.0-x86_64-apple-darwin.tar.gz.sha256",
+                "browser_download_url": "https://example.com/cdcx-1.2.0-x86_64-apple-darwin.tar.gz.sha256"
+            }),
+            serde_json::json!({
+                "name": "cdcx-1.2.0-aarch64-apple-darwin.tar.gz",
+                "browser_download_url": "https://example.com/cdcx-1.2.0-aarch64-apple-darwin.tar.gz"
+            }),
+        ];
+
+        let (url, name) = find_asset(&assets, "1.2.0", "x86_64-apple-darwin");
+        assert_eq!(
+            name.as_deref(),
+            Some("cdcx-1.2.0-x86_64-apple-darwin.tar.gz")
+        );
+        assert!(url.is_some());
+
+        let (url, _) = find_asset(&assets, "1.2.0", "x86_64-unknown-linux-musl");
+        assert!(url.is_none());
+    }
+
+    #[test]
+    fn test_find_asset_skips_sha256() {
+        let assets = vec![serde_json::json!({
+            "name": "cdcx-1.0.0-x86_64-apple-darwin.tar.gz.sha256",
+            "browser_download_url": "https://example.com/sha256"
+        })];
+        let (url, _) = find_asset(&assets, "1.0.0", "x86_64-apple-darwin");
+        assert!(url.is_none());
+    }
+
+    #[test]
+    fn test_checker_should_check_no_cache() {
+        let checker = UpdateChecker {
+            meta_path: PathBuf::from("/tmp/cdcx-test-nonexistent-meta.json"),
+            ttl: Duration::from_secs(86400),
+        };
+        assert!(checker.should_check());
+    }
+}

--- a/crates/cdcx-tui/src/app.rs
+++ b/crates/cdcx-tui/src/app.rs
@@ -34,6 +34,7 @@ pub struct App {
     pub active_tab: usize,
     pub mode: Mode,
     pub should_quit: bool,
+    pub should_update: bool,
     pub show_help: bool,
     pub show_spotlight: bool,
     pub split_view: bool,
@@ -60,6 +61,7 @@ impl App {
             active_tab: 0,
             mode: Mode::Normal,
             should_quit: false,
+            should_update: false,
             show_help: false,
             show_spotlight: false,
             split_view: false,
@@ -696,6 +698,15 @@ impl App {
     pub fn on_tick(&mut self) {
         self.tick_count += 1;
 
+        // Auto-quit after successful update to trigger restart
+        if matches!(
+            self.state.update_progress,
+            Some(crate::state::UpdateState::Done { .. })
+        ) {
+            self.should_quit = true;
+            return;
+        }
+
         // Check price alerts
         let triggered = self.state.check_alerts();
         for msg in triggered {
@@ -756,6 +767,24 @@ impl App {
                 if self.show_spotlight {
                     self.show_spotlight = false;
                     return;
+                }
+
+                // Click on update notice (row 0, left portion) → start download
+                if mouse.row == 0
+                    && self.state.update_notice.is_some()
+                    && self.state.update_progress.is_none()
+                {
+                    let notice_width = self
+                        .state
+                        .update_notice
+                        .as_ref()
+                        .map(|n| n.len() as u16 + 5)
+                        .unwrap_or(0)
+                        .min(self.state.terminal_size.0 / 2);
+                    if mouse.column < notice_width {
+                        self.should_update = true;
+                        return;
+                    }
                 }
 
                 // Click in tab bar area (rows 1-3) → switch tabs
@@ -1087,6 +1116,8 @@ mod tests {
             user_connection: crate::state::ConnectionStatus::Error,
             isolated_positions: std::collections::HashMap::new(),
             positions_snapshot: Vec::new(),
+            update_notice: None,
+            update_progress: None,
         };
         let mut app = App::new(state, &[]);
         // Seed market tab with an instrument so workflow triggers have something to select

--- a/crates/cdcx-tui/src/lib.rs
+++ b/crates/cdcx-tui/src/lib.rs
@@ -97,6 +97,13 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
     let mut loading_events = EventHandler::new(60); // fast tick for smooth animation
     let mut loading_state = loading::LoadingState::new();
 
+    // Update check channels — created early so the check runs in parallel with loading
+    let (update_tx, mut update_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let (progress_tx, mut progress_rx) =
+        tokio::sync::mpsc::unbounded_channel::<cdcx_core::update::UpdateProgress>();
+    let update_info: std::sync::Arc<tokio::sync::Mutex<Option<cdcx_core::update::ReleaseInfo>>> =
+        std::sync::Arc::new(tokio::sync::Mutex::new(None));
+
     // Spawn both fetches concurrently, collect results with animated loading
     let (instruments, instrument_types, initial_tickers) = {
         use tokio::sync::oneshot;
@@ -117,6 +124,36 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
             let result = fetch_tickers(&api_tick).await;
             let _ = tick_tx.send(result);
         });
+
+        // Background update check — runs in parallel with instruments + tickers fetch
+        {
+            let update_tx = update_tx.clone();
+            let update_info = update_info.clone();
+            tokio::spawn(async move {
+                let checker = cdcx_core::update::UpdateChecker::default();
+                let current = env!("CARGO_PKG_VERSION");
+                if let Some(info) = checker
+                    .cached_release_info()
+                    .filter(|i| cdcx_core::update::is_newer(&i.version, current))
+                {
+                    let v = info.version.clone();
+                    *update_info.lock().await = Some(info);
+                    let _ = update_tx.send(format!("v{} available \u{2014} click to update", v));
+                    return;
+                }
+                if checker.should_check() {
+                    if let Ok(info) = checker.fetch_latest().await {
+                        if cdcx_core::update::is_newer(&info.version, current) {
+                            let _ = update_tx.send(format!(
+                                "v{} available \u{2014} click to update",
+                                info.version
+                            ));
+                            *update_info.lock().await = Some(info);
+                        }
+                    }
+                }
+            });
+        }
 
         let mut instruments = None;
         let mut tickers = None;
@@ -226,6 +263,8 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
         pending_navigation: None,
         isolated_positions: std::collections::HashMap::new(),
         positions_snapshot: Vec::new(),
+        update_notice: None,
+        update_progress: None,
     };
 
     let watchlist = config.watchlist.clone();
@@ -361,6 +400,24 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
                                 last_subs = subs;
                                 let _ = terminal.clear();
                             }
+                            // Trigger download when update bar is clicked
+                            if app.should_update && app.state.update_progress.is_none() {
+                                app.should_update = false;
+                                app.state.update_progress =
+                                    Some(state::UpdateState::Downloading { downloaded: 0, total: None });
+                                let info_ref = update_info.clone();
+                                let ptx = progress_tx.clone();
+                                tokio::spawn(async move {
+                                    let info = info_ref.lock().await.clone();
+                                    if let Some(info) = info {
+                                        if let Err(e) = cdcx_core::update::download_and_install_with_progress(&info, ptx.clone()).await {
+                                            let _ = ptx.send(cdcx_core::update::UpdateProgress::Failed(e.to_string()));
+                                        }
+                                    } else {
+                                        let _ = ptx.send(cdcx_core::update::UpdateProgress::Failed("No release info available".into()));
+                                    }
+                                });
+                            }
                         }
                         Event::Tick => {
                             app.on_tick();
@@ -450,8 +507,47 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             }
+            notice = update_rx.recv() => {
+                if let Some(msg) = notice {
+                    app.state.update_notice = Some(msg);
+                }
+            }
+            prog = progress_rx.recv() => {
+                if let Some(p) = prog {
+                    match p {
+                        cdcx_core::update::UpdateProgress::Downloading { downloaded, total } => {
+                            app.state.update_progress =
+                                Some(state::UpdateState::Downloading { downloaded, total });
+                        }
+                        cdcx_core::update::UpdateProgress::Extracting => {
+                            app.state.update_progress = Some(state::UpdateState::Extracting);
+                        }
+                        cdcx_core::update::UpdateProgress::Installing => {
+                            app.state.update_progress = Some(state::UpdateState::Installing);
+                        }
+                        cdcx_core::update::UpdateProgress::Done => {
+                            let version = update_info.lock().await
+                                .as_ref()
+                                .map(|i| i.version.clone())
+                                .unwrap_or_else(|| "latest".into());
+                            app.state.update_progress = Some(state::UpdateState::Done { version });
+                            app.state.update_notice = None;
+                        }
+                        cdcx_core::update::UpdateProgress::Failed(msg) => {
+                            app.state.update_progress = Some(state::UpdateState::Failed(msg.clone()));
+                            app.state.toast(format!("Update failed: {}", msg), state::ToastStyle::Error);
+                        }
+                    }
+                }
+            }
         }
     }
+
+    // If update completed, restart with same args
+    let restart = matches!(
+        app.state.update_progress,
+        Some(state::UpdateState::Done { .. })
+    );
 
     stream_mgr.shutdown();
     if let Some(ref u) = user_stream_mgr {
@@ -459,7 +555,31 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
     crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture).ok();
     ratatui::restore();
+
+    if restart {
+        let exe = std::env::current_exe().expect("cannot find current binary");
+        let args: Vec<String> = std::env::args().collect();
+        eprintln!("Restarting cdcx...");
+        let err = exec_replace(&exe, &args);
+        eprintln!("Failed to restart: {}", err);
+        std::process::exit(1);
+    }
+
     Ok(())
+}
+
+#[cfg(unix)]
+fn exec_replace(exe: &std::path::Path, args: &[String]) -> std::io::Error {
+    use std::os::unix::process::CommandExt;
+    std::process::Command::new(exe).args(&args[1..]).exec()
+}
+
+#[cfg(not(unix))]
+fn exec_replace(exe: &std::path::Path, args: &[String]) -> std::io::Error {
+    match std::process::Command::new(exe).args(&args[1..]).spawn() {
+        Ok(_) => std::process::exit(0),
+        Err(e) => e,
+    }
 }
 
 fn load_cdcx_config() -> Result<Option<cdcx_core::config::Config>, cdcx_core::error::CdcxError> {

--- a/crates/cdcx-tui/src/state.rs
+++ b/crates/cdcx-tui/src/state.rs
@@ -129,6 +129,19 @@ pub struct AppState {
     /// Latest snapshot of all open positions (any margin type). Source of truth for
     /// the Positions tab and the isolated_positions cache. Updated via WS pushes.
     pub positions_snapshot: Vec<serde_json::Value>,
+    /// Update notice shown in the ticker tape when a newer CLI version is available.
+    pub update_notice: Option<String>,
+    /// Download progress state for in-TUI updates.
+    pub update_progress: Option<UpdateState>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UpdateState {
+    Downloading { downloaded: u64, total: Option<u64> },
+    Extracting,
+    Installing,
+    Done { version: String },
+    Failed(String),
 }
 
 impl AppState {

--- a/crates/cdcx-tui/src/widgets/ticker_tape.rs
+++ b/crates/cdcx-tui/src/widgets/ticker_tape.rs
@@ -1,16 +1,137 @@
 use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::Paragraph;
+use ratatui::widgets::{Gauge, Paragraph};
 use ratatui::Frame;
 
-use crate::state::AppState;
+use crate::state::{AppState, UpdateState};
 
 /// Draw a scrolling ticker tape showing top gainers and losers.
+/// When an update notice or progress is present, pins it to the left.
 pub fn draw_ticker_tape(frame: &mut Frame, area: Rect, state: &AppState, tick: u64) {
     if area.width < 10 {
         return;
     }
+
+    // If actively updating, show progress bar on the left instead of notice
+    let notice_width = state
+        .update_notice
+        .as_ref()
+        .map(|n| (n.len() as u16 + 5).min(area.width / 2))
+        .unwrap_or(area.width / 3);
+
+    let (tape_area, left_area) = if let Some(ref progress) = state.update_progress {
+        let width = notice_width.max(20).min(area.width / 2);
+        let [left, right] = ratatui::layout::Layout::horizontal([
+            ratatui::layout::Constraint::Length(width),
+            ratatui::layout::Constraint::Fill(1),
+        ])
+        .areas(area);
+
+        match progress {
+            UpdateState::Downloading { downloaded, total } => {
+                let (ratio, label) = if let Some(t) = total {
+                    let r = (*downloaded as f64 / *t as f64).min(1.0);
+                    let mb = *downloaded as f64 / 1_048_576.0;
+                    let total_mb = *t as f64 / 1_048_576.0;
+                    (r, format!("{:.1}/{:.1} MB", mb, total_mb))
+                } else {
+                    let mb = *downloaded as f64 / 1_048_576.0;
+                    (0.0, format!("{:.1} MB...", mb))
+                };
+                frame.render_widget(
+                    Gauge::default()
+                        .ratio(ratio)
+                        .label(label)
+                        .gauge_style(
+                            Style::default()
+                                .fg(state.theme.colors.accent)
+                                .bg(state.theme.colors.status_bar_bg),
+                        )
+                        .style(
+                            Style::default()
+                                .fg(state.theme.colors.status_bar_fg)
+                                .bg(state.theme.colors.status_bar_bg),
+                        ),
+                    left,
+                );
+            }
+            UpdateState::Extracting | UpdateState::Installing => {
+                let label = match progress {
+                    UpdateState::Extracting => "Extracting...",
+                    _ => "Installing...",
+                };
+                frame.render_widget(
+                    Gauge::default()
+                        .ratio(0.5)
+                        .label(label)
+                        .gauge_style(
+                            Style::default()
+                                .fg(state.theme.colors.accent)
+                                .bg(state.theme.colors.status_bar_bg),
+                        )
+                        .style(
+                            Style::default()
+                                .fg(state.theme.colors.status_bar_fg)
+                                .bg(state.theme.colors.status_bar_bg),
+                        ),
+                    left,
+                );
+            }
+            UpdateState::Done { version } => {
+                let text = format!(" \u{2714} Updated to v{} \u{2014} restarting... ", version);
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![Span::styled(
+                        text,
+                        Style::default()
+                            .fg(state.theme.colors.positive)
+                            .add_modifier(Modifier::BOLD),
+                    )]))
+                    .style(Style::default().bg(state.theme.colors.status_bar_bg)),
+                    left,
+                );
+            }
+            UpdateState::Failed(msg) => {
+                let short = if msg.len() > 30 { &msg[..30] } else { msg };
+                let text = format!(" \u{2717} {} ", short);
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![Span::styled(
+                        text,
+                        Style::default()
+                            .fg(state.theme.colors.negative)
+                            .add_modifier(Modifier::BOLD),
+                    )]))
+                    .style(Style::default().bg(state.theme.colors.status_bar_bg)),
+                    left,
+                );
+            }
+        }
+
+        (right, Some(left))
+    } else if let Some(ref notice) = state.update_notice {
+        let notice_width = (notice.len() as u16 + 5).min(area.width / 2);
+        let [left, right] = ratatui::layout::Layout::horizontal([
+            ratatui::layout::Constraint::Length(notice_width),
+            ratatui::layout::Constraint::Fill(1),
+        ])
+        .areas(area);
+
+        let text = format!(" \u{1f680} {} ", notice);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![Span::styled(
+                text,
+                Style::default().fg(state.theme.colors.muted),
+            )]))
+            .style(Style::default().bg(state.theme.colors.status_bar_bg)),
+            left,
+        );
+        (right, Some(left))
+    } else {
+        (area, None)
+    };
+
+    let _ = left_area;
+    let area = tape_area;
 
     let mut entries: Vec<(&str, f64, f64)> = state
         .tickers


### PR DESCRIPTION
close #14 
## Summary
- Add `cdcx update` CLI command (with `--check` flag for check-only mode)
- Background update check on every CLI invocation, throttled to once/24h via cache file (`~/.cache/cdcx/update-meta.json`)
- TUI integration: update notice in ticker tape row → click to download → Gauge progress bar → atomic binary replace → `exec()` restart
- Update check runs in parallel with TUI loading screen (non-blocking)
- Full release info (download URL, asset name, html URL) cached to avoid redundant GitHub API calls
- Release URL derived from `CARGO_PKG_REPOSITORY` — no hardcoded GitHub URLs
- Platform-aware binary asset matching for all 6 release targets (x86_64/aarch64 × linux-musl/macos/windows)
- Windows zip extraction via PowerShell `Expand-Archive`

## Test plan
- [x] Run `cdcx update --check` — verify it reports current version and checks GitHub
- [x] Run `cdcx update` — verify download, extraction, and binary replacement
- [x] Launch TUI, verify update notice appears in ticker tape when a newer version exists
- [x] Click update notice in TUI — verify Gauge progress bar replaces notice
- [x] Verify TUI auto-restarts after successful update
- [x] Verify update check does not fire more than once per 24h (check `~/.cache/cdcx/update-meta.json` timestamps)
- [x] Verify no API call on TUI launch when cache has valid release info

🤖 Generated with [Claude Code](https://claude.com/claude-code)