### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cdcx-cli"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "assert_cmd",
  "cdcx-core",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "cdcx-core"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "cdcx-tui"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "cdcx-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cdcx-core", "crates/cdcx-cli", "crates/cdcx-tui"]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Agent-first CLI for Crypto.com Exchange API v1"


### PR DESCRIPTION
## Summary
- Version bump to 1.2.0 for self-update system release
- Includes all self-update feature implementation (background checking, TUI integration, atomic binary replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)