### PR TITLE
feat(tui): unify list interactions across all tabs

### DIFF
--- a/crates/cdcx-tui/src/app.rs
+++ b/crates/cdcx-tui/src/app.rs
@@ -363,11 +363,24 @@ impl App {
 
         // Handle cross-tab navigation requests (e.g. watchlist Enter → market detail)
         if let Some((target_tab, instrument)) = self.state.pending_navigation.take() {
+            let origin_tab = TabKind::ALL[self.active_tab];
+            // Set origin before calling navigate_to_instrument so the tab can read it
+            self.state.pending_return_tab = Some(origin_tab);
             if let Some(idx) = TabKind::ALL.iter().position(|t| *t == target_tab) {
                 self.active_tab = idx;
                 if let Some(tab) = self.tabs.get_mut(idx) {
                     tab.navigate_to_instrument(&instrument, &self.state);
                 }
+            }
+            // Clear from state — Market tab has stored it internally
+            self.state.pending_return_tab = None;
+            return;
+        }
+
+        // Handle return-to-previous-tab requests (Esc from detail navigated via another tab)
+        if let Some(return_tab) = self.state.pending_return_tab.take() {
+            if let Some(idx) = TabKind::ALL.iter().position(|t| *t == return_tab) {
+                self.active_tab = idx;
             }
             return;
         }
@@ -820,6 +833,19 @@ impl App {
             }
             _ => {}
         }
+
+        // Handle cross-tab navigation set by on_click/on_double_click
+        if let Some((target_tab, instrument)) = self.state.pending_navigation.take() {
+            let origin_tab = TabKind::ALL[self.active_tab];
+            self.state.pending_return_tab = Some(origin_tab);
+            if let Some(idx) = TabKind::ALL.iter().position(|t| *t == target_tab) {
+                self.active_tab = idx;
+                if let Some(tab) = self.tabs.get_mut(idx) {
+                    tab.navigate_to_instrument(&instrument, &self.state);
+                }
+            }
+            self.state.pending_return_tab = None;
+        }
     }
 
     pub fn active_subscriptions(&self) -> Vec<String> {
@@ -1112,6 +1138,7 @@ mod tests {
             paper_engine: None,
             volume_unit: crate::state::VolumeUnit::Usd,
             pending_navigation: None,
+            pending_return_tab: None,
             instrument_types: std::collections::HashMap::new(),
             user_connection: crate::state::ConnectionStatus::Error,
             isolated_positions: std::collections::HashMap::new(),

--- a/crates/cdcx-tui/src/lib.rs
+++ b/crates/cdcx-tui/src/lib.rs
@@ -261,6 +261,7 @@ pub async fn run(opts: TuiOptions) -> Result<(), Box<dyn std::error::Error>> {
         paper_engine: cdcx_core::paper::engine::PaperEngine::load_or_init(10000.0).ok(),
         volume_unit: crate::state::VolumeUnit::Usd,
         pending_navigation: None,
+        pending_return_tab: None,
         isolated_positions: std::collections::HashMap::new(),
         positions_snapshot: Vec::new(),
         update_notice: None,

--- a/crates/cdcx-tui/src/state.rs
+++ b/crates/cdcx-tui/src/state.rs
@@ -122,6 +122,8 @@ pub struct AppState {
     pub volume_unit: VolumeUnit,
     /// Cross-tab navigation request: (target tab, instrument to show in detail).
     pub pending_navigation: Option<(crate::tabs::TabKind, String)>,
+    /// Return to a previous tab (e.g. Esc from detail navigated via another tab).
+    pub pending_return_tab: Option<crate::tabs::TabKind>,
     /// instrument_name → isolation_id for currently-open isolated-margin positions.
     /// Populated from `user.positions` WS channel + `private/get-positions` REST responses.
     /// Required to add to / trim an existing isolated position without triggering error 617.

--- a/crates/cdcx-tui/src/tabs/history.rs
+++ b/crates/cdcx-tui/src/tabs/history.rs
@@ -7,9 +7,24 @@ use ratatui::Frame;
 
 use crate::format::format_price;
 use crate::state::{AppState, RestRequest};
-use crate::tabs::{DataEvent, Tab};
+use crate::tabs::{DataEvent, Tab, TabKind};
 
-const PAGE_SIZE: usize = 50;
+const PAGE_SIZE: usize = 100;
+
+fn days_to_ymd(days_since_epoch: i64) -> (i64, u32, u32) {
+    // Civil days to Y/M/D (algorithm from http://howardhinnant.github.io/date_algorithms.html)
+    let z = days_since_epoch + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
 
 #[derive(Debug, Clone)]
 struct HistoryOrder {
@@ -20,13 +35,19 @@ struct HistoryOrder {
     quantity: f64,
     status: String,
     time: String,
+    create_time_ns: u64,
 }
 
 pub struct HistoryTab {
     orders: Vec<HistoryOrder>,
     loaded: bool,
+    requesting: bool,
     selected: usize,
-    page: usize,
+    scroll_offset: usize,
+    /// Stack of end_time cursors for previous pages (enables going back).
+    cursor_stack: Vec<u64>,
+    /// The end_time cursor for the next page (earliest create_time of current batch).
+    next_cursor: Option<u64>,
     has_next: bool,
 }
 
@@ -41,20 +62,33 @@ impl HistoryTab {
         Self {
             orders: vec![],
             loaded: false,
+            requesting: false,
             selected: 0,
-            page: 0,
+            scroll_offset: 0,
+            cursor_stack: vec![],
+            next_cursor: None,
             has_next: true,
         }
     }
 
-    fn request_data(&self, state: &AppState) {
-        if state.authenticated && !state.paper_mode {
+    fn request_data(&mut self, state: &AppState) {
+        if state.authenticated && !state.paper_mode && !self.requesting {
+            self.requesting = true;
+            let mut params = serde_json::json!({"limit": PAGE_SIZE});
+            if let Some(cursor) = self.next_cursor {
+                params["end_time"] = serde_json::json!(cursor);
+            }
             let _ = state.rest_tx.send(RestRequest {
                 method: "private/get-order-history".into(),
-                params: serde_json::json!({"page_size": PAGE_SIZE.to_string(), "page": self.page.to_string()}),
+                params,
                 is_private: true,
             });
         }
+    }
+
+    fn visible_rows(&self, terminal_height: u16) -> usize {
+        // terminal_height - ticker(1) - tab_bar(3) - status(1) - footer(1) - table_header(1) = data rows
+        (terminal_height as usize).saturating_sub(7)
     }
 
     fn load_paper_history(&mut self, state: &AppState) {
@@ -68,11 +102,12 @@ impl HistoryTab {
                     HistoryOrder {
                         instrument: t.instrument_name.clone(),
                         side: format!("{:?}", t.side).to_uppercase(),
-                        order_type: "MARKET".into(), // paper trades are always filled
+                        order_type: "MARKET".into(),
                         price: format_price(t.price),
                         quantity: t.quantity,
                         status: "FILLED".into(),
-                        time: t.timestamp.chars().take(19).collect(), // trim to datetime
+                        time: t.timestamp.chars().take(19).collect(),
+                        create_time_ns: 0,
                     }
                 })
                 .collect();
@@ -87,31 +122,60 @@ impl Tab for HistoryTab {
             KeyCode::Up => {
                 if self.selected > 0 {
                     self.selected -= 1;
+                    if self.selected < self.scroll_offset {
+                        self.scroll_offset = self.selected;
+                    }
                 }
                 true
             }
             KeyCode::Down => {
                 if self.selected < self.orders.len().saturating_sub(1) {
                     self.selected += 1;
+                    let vis = self.visible_rows(state.terminal_size.1);
+                    if self.selected >= self.scroll_offset + vis {
+                        self.scroll_offset = self.selected + 1 - vis;
+                    }
                 }
                 true
             }
-            KeyCode::Right if !state.paper_mode && self.has_next => {
-                self.page += 1;
+            KeyCode::Right if !state.paper_mode && self.loaded && self.has_next => {
+                // Push current cursor so Left can restore it
+                if let Some(first_ts) = self.orders.first().map(|o| o.create_time_ns) {
+                    self.cursor_stack.push(first_ts);
+                }
                 self.loaded = false;
                 self.selected = 0;
+                self.scroll_offset = 0;
                 self.request_data(state);
                 true
             }
-            KeyCode::Left if !state.paper_mode && self.page > 0 => {
-                self.page -= 1;
+            KeyCode::Left if !state.paper_mode && self.loaded && !self.cursor_stack.is_empty() => {
+                // Pop previous page's start_time and use it as the new end_time + 1ns
+                // to re-fetch that page. If stack is empty after pop, fetch first page.
+                let prev_cursor = self.cursor_stack.pop();
+                // The cursor we popped was the first (newest) item's create_time of that page.
+                // To re-fetch that page, we need end_time > that timestamp (or no end_time for first page).
+                if self.cursor_stack.is_empty() {
+                    self.next_cursor = None;
+                } else {
+                    self.next_cursor = prev_cursor;
+                }
                 self.loaded = false;
                 self.selected = 0;
+                self.scroll_offset = 0;
                 self.request_data(state);
+                true
+            }
+            KeyCode::Enter => {
+                if let Some(order) = self.orders.get(self.selected) {
+                    state.pending_navigation =
+                        Some((TabKind::Market, order.instrument.clone()));
+                }
                 true
             }
             KeyCode::Char('r') => {
                 self.loaded = false;
+                self.requesting = false;
                 true
             }
             _ => false,
@@ -125,6 +189,7 @@ impl Tab for HistoryTab {
         }
         match event {
             DataEvent::RestResponse { method, data } if method == "private/get-order-history" => {
+                self.requesting = false;
                 let arr_opt = data
                     .get("order_list")
                     .and_then(|d| d.as_array())
@@ -133,60 +198,88 @@ impl Tab for HistoryTab {
                     self.has_next = arr.len() >= PAGE_SIZE;
                     self.orders = arr
                         .iter()
-                        .map(|item| HistoryOrder {
-                            instrument: item
-                                .get("instrument_name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            side: item
-                                .get("side")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            order_type: item
-                                .get("order_type")
-                                .or_else(|| item.get("type"))
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            price: format_price(
-                                item.get("avg_price")
+                        .map(|item| {
+                            let create_time_ns = item
+                                .get("create_time_ns")
+                                .and_then(|v| v.as_u64())
+                                .or_else(|| {
+                                    item.get("create_time")
+                                        .and_then(|v| v.as_u64())
+                                        .map(|ms| ms * 1_000_000)
+                                })
+                                .unwrap_or(0);
+                            HistoryOrder {
+                                instrument: item
+                                    .get("instrument_name")
                                     .and_then(|v| v.as_str())
-                                    .filter(|s| *s != "0")
-                                    .or_else(|| {
-                                        item.get("limit_price")
-                                            .and_then(|v| v.as_str())
-                                            .filter(|s| *s != "0")
-                                    })
-                                    .or_else(|| {
-                                        item.get("price")
-                                            .and_then(|v| v.as_str())
-                                            .filter(|s| *s != "0")
-                                    })
+                                    .unwrap_or("")
+                                    .to_string(),
+                                side: item
+                                    .get("side")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                order_type: item
+                                    .get("order_type")
+                                    .or_else(|| item.get("type"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                price: format_price(
+                                    item.get("avg_price")
+                                        .and_then(|v| v.as_str())
+                                        .filter(|s| *s != "0")
+                                        .or_else(|| {
+                                            item.get("limit_price")
+                                                .and_then(|v| v.as_str())
+                                                .filter(|s| *s != "0")
+                                        })
+                                        .or_else(|| {
+                                            item.get("price")
+                                                .and_then(|v| v.as_str())
+                                                .filter(|s| *s != "0")
+                                        })
+                                        .and_then(|s| s.parse().ok())
+                                        .unwrap_or(0.0),
+                                ),
+                                quantity: item
+                                    .get("quantity")
+                                    .and_then(|v| v.as_str())
                                     .and_then(|s| s.parse().ok())
                                     .unwrap_or(0.0),
-                            ),
-                            quantity: item
-                                .get("quantity")
-                                .and_then(|v| v.as_str())
-                                .and_then(|s| s.parse().ok())
-                                .unwrap_or(0.0),
-                            status: item
-                                .get("status")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string(),
-                            time: item
-                                .get("create_time")
-                                .and_then(|v| v.as_u64())
-                                .map(|ts| {
-                                    let s = ts / 1000;
-                                    format!("{:02}:{:02}", (s / 3600) % 24, (s / 60) % 60)
-                                })
-                                .unwrap_or_default(),
+                                status: item
+                                    .get("status")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                                time: item
+                                    .get("create_time")
+                                    .and_then(|v| v.as_u64())
+                                    .map(|ms| {
+                                        let secs = (ms / 1000) as i64;
+                                        let days = secs / 86400;
+                                        let time_of_day = secs % 86400;
+                                        let hours = time_of_day / 3600;
+                                        let minutes = (time_of_day % 3600) / 60;
+                                        // Days since Unix epoch to Y-M-D
+                                        let (y, m, d) = days_to_ymd(days);
+                                        format!(
+                                            "{:04}-{:02}-{:02} {:02}:{:02}",
+                                            y, m, d, hours, minutes
+                                        )
+                                    })
+                                    .unwrap_or_default(),
+                                create_time_ns,
+                            }
                         })
                         .collect();
+                    // Use the earliest create_time as cursor for next page
+                    self.next_cursor = self
+                        .orders
+                        .iter()
+                        .map(|o| o.create_time_ns)
+                        .filter(|t| *t > 0)
+                        .min();
                     self.loaded = true;
                 }
             }
@@ -225,8 +318,8 @@ impl Tab for HistoryTab {
             frame.render_widget(
                 Paragraph::new(if state.paper_mode {
                     "No paper trades yet."
-                } else if self.page > 0 {
-                    "No more orders on this page."
+                } else if !self.cursor_stack.is_empty() {
+                    "No more orders."
                 } else {
                     "No order history."
                 })
@@ -255,15 +348,19 @@ impl Tab for HistoryTab {
                 Constraint::Length(14),
                 Constraint::Length(12),
                 Constraint::Length(16),
-                Constraint::Length(10),
+                Constraint::Length(16),
             ];
 
-            let rows: Vec<Row> = self
-                .orders
+            let vis = (table_area.height as usize).saturating_sub(1);
+            let end = (self.scroll_offset + vis).min(self.orders.len());
+            let visible_slice = &self.orders[self.scroll_offset..end];
+
+            let rows: Vec<Row> = visible_slice
                 .iter()
                 .enumerate()
-                .map(|(i, o)| {
-                    let is_selected = i == self.selected;
+                .map(|(vi, o)| {
+                    let abs_idx = self.scroll_offset + vi;
+                    let is_selected = abs_idx == self.selected;
                     let side_color = if o.side == "BUY" {
                         state.theme.colors.positive
                     } else {
@@ -321,7 +418,7 @@ impl Tab for HistoryTab {
         let page_info = if state.paper_mode {
             format!("{} trades", self.orders.len())
         } else {
-            format!("Page {}", self.page + 1)
+            format!("Page {}", self.cursor_stack.len() + 1)
         };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
@@ -346,10 +443,40 @@ impl Tab for HistoryTab {
         vec![]
     }
 
+    fn on_click(&mut self, row: u16, _col: u16, _state: &mut AppState) -> bool {
+        // Layout: row 0 = table header, row 1+ = data rows, last row = footer
+        if row >= 1 {
+            let data_row = (row - 1) as usize + self.scroll_offset;
+            if data_row < self.orders.len() {
+                self.selected = data_row;
+                return true;
+            }
+        }
+        false
+    }
+
+    fn on_double_click(&mut self, row: u16, _col: u16, state: &mut AppState) -> bool {
+        if row >= 1 {
+            let data_row = (row - 1) as usize + self.scroll_offset;
+            if data_row < self.orders.len() {
+                self.selected = data_row;
+                if let Some(order) = self.orders.get(self.selected) {
+                    state.pending_navigation =
+                        Some((TabKind::Market, order.instrument.clone()));
+                }
+                return true;
+            }
+        }
+        false
+    }
+
     fn on_activate(&mut self) {
         self.loaded = false;
+        self.requesting = false;
         self.has_next = true;
-        self.page = 0;
+        self.cursor_stack.clear();
+        self.next_cursor = None;
         self.selected = 0;
+        self.scroll_offset = 0;
     }
 }

--- a/crates/cdcx-tui/src/tabs/history.rs
+++ b/crates/cdcx-tui/src/tabs/history.rs
@@ -98,17 +98,15 @@ impl HistoryTab {
                 .trade_history
                 .iter()
                 .rev()
-                .map(|t| {
-                    HistoryOrder {
-                        instrument: t.instrument_name.clone(),
-                        side: format!("{:?}", t.side).to_uppercase(),
-                        order_type: "MARKET".into(),
-                        price: format_price(t.price),
-                        quantity: t.quantity,
-                        status: "FILLED".into(),
-                        time: t.timestamp.chars().take(19).collect(),
-                        create_time_ns: 0,
-                    }
+                .map(|t| HistoryOrder {
+                    instrument: t.instrument_name.clone(),
+                    side: format!("{:?}", t.side).to_uppercase(),
+                    order_type: "MARKET".into(),
+                    price: format_price(t.price),
+                    quantity: t.quantity,
+                    status: "FILLED".into(),
+                    time: t.timestamp.chars().take(19).collect(),
+                    create_time_ns: 0,
                 })
                 .collect();
             self.loaded = true;
@@ -168,8 +166,7 @@ impl Tab for HistoryTab {
             }
             KeyCode::Enter => {
                 if let Some(order) = self.orders.get(self.selected) {
-                    state.pending_navigation =
-                        Some((TabKind::Market, order.instrument.clone()));
+                    state.pending_navigation = Some((TabKind::Market, order.instrument.clone()));
                 }
                 true
             }
@@ -461,8 +458,7 @@ impl Tab for HistoryTab {
             if data_row < self.orders.len() {
                 self.selected = data_row;
                 if let Some(order) = self.orders.get(self.selected) {
-                    state.pending_navigation =
-                        Some((TabKind::Market, order.instrument.clone()));
+                    state.pending_navigation = Some((TabKind::Market, order.instrument.clone()));
                 }
                 return true;
             }

--- a/crates/cdcx-tui/src/tabs/market.rs
+++ b/crates/cdcx-tui/src/tabs/market.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use crate::format::{format_compact, format_price};
 use crate::state::{AppState, RestRequest};
-use crate::tabs::{DataEvent, Tab};
+use crate::tabs::{DataEvent, Tab, TabKind};
 use crate::widgets::candlestick::{
     draw_candlestick, draw_compare_charts, fill_candle_gaps, Candle,
 };
@@ -96,6 +96,7 @@ pub struct MarketTab {
     compare_instruments: Vec<String>,
     compare_selected: usize,
     picker: Option<InstrumentPicker>,
+    navigated_from: Option<TabKind>,
 }
 
 impl Default for MarketTab {
@@ -127,6 +128,7 @@ impl MarketTab {
             compare_instruments: vec![],
             compare_selected: 0,
             picker: None,
+            navigated_from: None,
         }
     }
 
@@ -138,6 +140,7 @@ impl MarketTab {
 
     fn enter_detail(&mut self, state: &AppState) {
         if let Some(inst) = self.selected_instrument().map(String::from) {
+            self.navigated_from = None;
             self.enter_detail_for(&inst, state);
         }
     }
@@ -270,8 +273,17 @@ impl MarketTab {
     }
 
     fn visible_rows(&self, area_height: u16) -> usize {
-        // Subtract header line (1) + table header (1) + separator (1) + footer (1) = 4
+        // When called from on_key with terminal_height - 4:
+        //   terminal_height - 4 (ticker+tab_bar) - 4 (header+table_hdr+footer+status) = data rows
+        // When called from draw with table_area.height:
+        //   callers must subtract 1 for the table header themselves or use
+        //   visible_rows_in_table() instead.
         (area_height as usize).saturating_sub(4)
+    }
+
+    fn visible_rows_in_table(&self, table_area_height: u16) -> usize {
+        // table_area only contains the Table widget: 1 header row + N data rows
+        (table_area_height as usize).saturating_sub(1)
     }
 
     /// Rebuild categories from instrument type data. Called after instruments are loaded.
@@ -376,6 +388,9 @@ impl Tab for MarketTab {
                 return match key.code {
                     KeyCode::Esc => {
                         self.view_mode = ViewMode::Table;
+                        if let Some(origin) = self.navigated_from.take() {
+                            state.pending_return_tab = Some(origin);
+                        }
                         true
                     }
                     KeyCode::Char('k') => {
@@ -896,7 +911,7 @@ impl Tab for MarketTab {
             ));
         } else {
             let total = self.filtered_instruments.len();
-            let vis = self.visible_rows(table_area.height);
+            let vis = self.visible_rows_in_table(table_area.height);
             let end = (self.scroll_offset + vis).min(total);
             if total > 0 {
                 spans.push(Span::styled(
@@ -953,7 +968,7 @@ impl Tab for MarketTab {
             widths_base
         };
 
-        let vis = self.visible_rows(table_area.height);
+        let vis = self.visible_rows_in_table(table_area.height);
         let end = (self.scroll_offset + vis).min(self.filtered_instruments.len());
         let visible_slice = &self.filtered_instruments[self.scroll_offset..end];
 
@@ -1126,13 +1141,18 @@ impl Tab for MarketTab {
             .map(|s| s.as_str())
     }
 
-    fn on_click(&mut self, row: u16, _col: u16, _state: &mut AppState) -> bool {
+    fn on_click(&mut self, row: u16, _col: u16, state: &mut AppState) -> bool {
         if self.view_mode != ViewMode::Table {
             return false;
         }
         // Content area layout: row 0 = category header, row 1 = table header, row 2+ = data
         if row >= 2 {
-            let table_row = (row - 2) as usize + self.scroll_offset;
+            let visual_row = (row - 2) as usize;
+            let vis = self.visible_rows(state.terminal_size.1.saturating_sub(4));
+            if visual_row >= vis {
+                return false;
+            }
+            let table_row = visual_row + self.scroll_offset;
             if table_row < self.filtered_instruments.len() {
                 self.selected = table_row;
                 return true;
@@ -1146,7 +1166,12 @@ impl Tab for MarketTab {
             return false;
         }
         if row >= 2 {
-            let table_row = (row - 2) as usize + self.scroll_offset;
+            let visual_row = (row - 2) as usize;
+            let vis = self.visible_rows(state.terminal_size.1.saturating_sub(4));
+            if visual_row >= vis {
+                return false;
+            }
+            let table_row = visual_row + self.scroll_offset;
             if table_row < self.filtered_instruments.len() {
                 self.selected = table_row;
                 self.enter_detail(state);
@@ -1181,6 +1206,7 @@ impl Tab for MarketTab {
     }
 
     fn navigate_to_instrument(&mut self, instrument: &str, state: &AppState) {
+        self.navigated_from = state.pending_return_tab;
         self.enter_detail_for(instrument, state);
     }
 }

--- a/crates/cdcx-tui/src/tabs/orders.rs
+++ b/crates/cdcx-tui/src/tabs/orders.rs
@@ -182,8 +182,7 @@ impl Tab for OrdersTab {
             }
             KeyCode::Enter => {
                 if let Some(order) = self.orders.get(self.selected) {
-                    state.pending_navigation =
-                        Some((TabKind::Market, order.instrument.clone()));
+                    state.pending_navigation = Some((TabKind::Market, order.instrument.clone()));
                 }
                 true
             }
@@ -384,8 +383,10 @@ impl Tab for OrdersTab {
             let data_row = (row - 1) as usize;
             if data_row < self.orders.len() {
                 self.selected = data_row;
-                state.pending_navigation =
-                    Some((TabKind::Market, self.orders[self.selected].instrument.clone()));
+                state.pending_navigation = Some((
+                    TabKind::Market,
+                    self.orders[self.selected].instrument.clone(),
+                ));
                 return true;
             }
         }

--- a/crates/cdcx-tui/src/tabs/orders.rs
+++ b/crates/cdcx-tui/src/tabs/orders.rs
@@ -7,7 +7,7 @@ use ratatui::Frame;
 
 use crate::format::format_price;
 use crate::state::{AppState, RestRequest};
-use crate::tabs::{DataEvent, Tab};
+use crate::tabs::{DataEvent, Tab, TabKind};
 
 #[derive(Debug, Clone)]
 struct Order {
@@ -166,7 +166,7 @@ impl OrdersTab {
 }
 
 impl Tab for OrdersTab {
-    fn on_key(&mut self, key: KeyEvent, _state: &mut AppState) -> bool {
+    fn on_key(&mut self, key: KeyEvent, state: &mut AppState) -> bool {
         match key.code {
             KeyCode::Up => {
                 if self.selected > 0 {
@@ -177,6 +177,13 @@ impl Tab for OrdersTab {
             KeyCode::Down => {
                 if self.selected < self.orders.len().saturating_sub(1) {
                     self.selected += 1;
+                }
+                true
+            }
+            KeyCode::Enter => {
+                if let Some(order) = self.orders.get(self.selected) {
+                    state.pending_navigation =
+                        Some((TabKind::Market, order.instrument.clone()));
                 }
                 true
             }
@@ -358,5 +365,30 @@ impl Tab for OrdersTab {
         self.orders
             .get(self.selected)
             .map(|o| o.instrument.as_str())
+    }
+
+    fn on_click(&mut self, row: u16, _col: u16, _state: &mut AppState) -> bool {
+        // Layout: row 0 = table header, row 1+ = data rows
+        if row >= 1 {
+            let data_row = (row - 1) as usize;
+            if data_row < self.orders.len() {
+                self.selected = data_row;
+                return true;
+            }
+        }
+        false
+    }
+
+    fn on_double_click(&mut self, row: u16, _col: u16, state: &mut AppState) -> bool {
+        if row >= 1 {
+            let data_row = (row - 1) as usize;
+            if data_row < self.orders.len() {
+                self.selected = data_row;
+                state.pending_navigation =
+                    Some((TabKind::Market, self.orders[self.selected].instrument.clone()));
+                return true;
+            }
+        }
+        false
     }
 }

--- a/crates/cdcx-tui/src/tabs/positions.rs
+++ b/crates/cdcx-tui/src/tabs/positions.rs
@@ -72,7 +72,8 @@ impl PositionsTab {
                     }
                 })
                 .collect();
-            self.positions.sort_by(|a, b| a.instrument.cmp(&b.instrument));
+            self.positions
+                .sort_by(|a, b| a.instrument.cmp(&b.instrument));
             self.loaded = true;
         }
     }
@@ -95,7 +96,8 @@ impl PositionsTab {
             .iter()
             .filter_map(|item| parse_position_record(item, state))
             .collect();
-        self.positions.sort_by(|a, b| a.instrument.cmp(&b.instrument));
+        self.positions
+            .sort_by(|a, b| a.instrument.cmp(&b.instrument));
         // Immediately apply the same ticker-driven recompute the tick path uses,
         // otherwise the WS payload's zero-initialised mark/pnl flashes on screen
         // for one frame before the next tick fills it in.

--- a/crates/cdcx-tui/src/tabs/positions.rs
+++ b/crates/cdcx-tui/src/tabs/positions.rs
@@ -72,6 +72,7 @@ impl PositionsTab {
                     }
                 })
                 .collect();
+            self.positions.sort_by(|a, b| a.instrument.cmp(&b.instrument));
             self.loaded = true;
         }
     }
@@ -94,6 +95,7 @@ impl PositionsTab {
             .iter()
             .filter_map(|item| parse_position_record(item, state))
             .collect();
+        self.positions.sort_by(|a, b| a.instrument.cmp(&b.instrument));
         // Immediately apply the same ticker-driven recompute the tick path uses,
         // otherwise the WS payload's zero-initialised mark/pnl flashes on screen
         // for one frame before the next tick fills it in.
@@ -425,6 +427,36 @@ impl Tab for PositionsTab {
         self.positions
             .get(self.selected)
             .map(|p| p.instrument.as_str())
+    }
+
+    fn on_click(&mut self, row: u16, _col: u16, _state: &mut AppState) -> bool {
+        if self.detail_position.is_some() {
+            return false;
+        }
+        // Layout: row 0 = table header, row 1+ = data rows
+        if row >= 1 {
+            let data_row = (row - 1) as usize;
+            if data_row < self.positions.len() {
+                self.selected = data_row;
+                return true;
+            }
+        }
+        false
+    }
+
+    fn on_double_click(&mut self, row: u16, _col: u16, _state: &mut AppState) -> bool {
+        if self.detail_position.is_some() {
+            return false;
+        }
+        if row >= 1 {
+            let data_row = (row - 1) as usize;
+            if data_row < self.positions.len() {
+                self.selected = data_row;
+                self.detail_position = Some(self.selected);
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/crates/cdcx-tui/src/tabs/watchlist.rs
+++ b/crates/cdcx-tui/src/tabs/watchlist.rs
@@ -218,6 +218,37 @@ impl Tab for WatchlistTab {
     fn selected_instrument(&self) -> Option<&str> {
         self.instruments.get(self.selected).map(|s| s.as_str())
     }
+
+    fn on_click(&mut self, row: u16, _col: u16, _state: &mut AppState) -> bool {
+        if self.picker.is_some() {
+            return false;
+        }
+        // Layout: row 0 = table header, row 1+ = data rows
+        if row >= 1 {
+            let data_row = (row - 1) as usize;
+            if data_row < self.instruments.len() {
+                self.selected = data_row;
+                return true;
+            }
+        }
+        false
+    }
+
+    fn on_double_click(&mut self, row: u16, _col: u16, state: &mut AppState) -> bool {
+        if self.picker.is_some() {
+            return false;
+        }
+        if row >= 1 {
+            let data_row = (row - 1) as usize;
+            if data_row < self.instruments.len() {
+                self.selected = data_row;
+                state.pending_navigation =
+                    Some((TabKind::Market, self.instruments[self.selected].clone()));
+                return true;
+            }
+        }
+        false
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add mouse click/double-click and Enter key navigation to all list tabs (History, Watchlist, Orders, Positions) — previously only Market tab supported mouse interaction
- Fix Market tab empty space at bottom: clicking empty rows no longer selects hidden items or enters detail
- Fix History tab over-scroll: selected item now stays within visible bounds with proper scroll windowing
- Fix History pagination to use correct API cursor-based pagination (`end_time`/`limit`) instead of non-existent `page_size`/`page` params
- Esc from Market detail returns to the originating tab when navigated via another tab
- Positions tab now uses stable sort (by instrument name) to prevent visual reordering on load
- History time column shows full `YYYY-MM-DD HH:MM` format

## Test plan
- [ ] Click and double-click items in Watchlist, History, Orders, Positions tabs
- [ ] Verify double-click / Enter navigates to Market detail for the selected instrument
- [ ] Press Esc in Market detail after navigating from Watchlist — should return to Watchlist
- [ ] Scroll down in History tab with many items — selected row should stay visible
- [ ] Navigate pages in History with Right/Left arrows — verify single API request per page
- [ ] Verify no navigation beyond last page (Right arrow disabled when no more records)
- [ ] Open Positions tab — verify list order is stable across re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)